### PR TITLE
Import skills from OpenHands/extensions PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/skills/adapt-yourself/README.md
+++ b/skills/adapt-yourself/README.md
@@ -1,0 +1,8 @@
+# adapt-yourself
+
+This skill is a playbook for “self-modification” requests:
+
+- deciding whether the user actually needs code changes, vs.
+- adding a repo/user skill, always-on repo instructions (`AGENTS.md`), hooks (`.openhands/hooks.json`), plugins, or MCP tooling.
+
+The canonical instructions live in [`SKILL.md`](SKILL.md).

--- a/skills/adapt-yourself/SKILL.md
+++ b/skills/adapt-yourself/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: adapt-yourself
+description: Decide how to make OpenHands adapt/improve itself persistently (after restart) by choosing between repo/user skills, always-on instructions, hooks, plugins, MCP servers, or code changes in OpenHands-CLI and software-agent-sdk. Includes uv + uv tool workflows and restart/reload behavior.
+triggers:
+- modify yourself
+- change your behavior
+- self-modify
+- adapt yourself
+- self modification
+- hack openhands
+- .agents/skills
+- hooks.json
+- plugin.json
+---
+
+# Modify OpenHands (self-modification playbook)
+
+When a user says things like “modify yourself to do X” or “remember this next time”, **don’t jump to editing Python code**.
+OpenHands has multiple extensibility layers; choose the *smallest*, *safest*, and *most persistent* mechanism that matches the user’s intent.
+
+This skill is about **persistent** changes that should still apply after the user reloads or restarts the CLI / app. If the user wants behavior only for the current conversation, you don't need the mechanisms in this skill—just follow their instructions directly in this session.
+
+## 0) First: clarify what kind of change the user wants
+
+Clarify the **scope** and **type** of the change (skip questions the user already answered):
+
+1. **Persistence scope**: Should this change apply…
+   - for this *repository/workspace*?
+   - for *all repos on this machine* (user-global)?
+   - for *everyone* (contribution upstream / extensions registry)?
+2. **Change type**: Is it primarily…
+   - instructions/workflow (“when I ask for X, do Y”)?
+   - a safety/policy constraint (“never run rm -rf”, “ask before network calls”)?
+   - a new capability/tool integration (GitHub, Jira, internal APIs, etc.)?
+   - a bug fix / UI change in the CLI or SDK?
+3. **Where do they run OpenHands?**
+   - `uv tool install openhands` (tool environment)
+   - from a local clone (developer workflow)
+   - via a remote runtime / server
+
+Then follow the decision tree below.
+
+## 1) Prefer non-code extensibility (often enough)
+
+### 1.1 Write a skill (AgentSkills / progressive disclosure)
+
+Use when the user wants repeatable expertise/workflows, e.g.:
+- “When I say ‘release notes’, use this structure”
+- “Here’s how we do migrations in our company”
+- “Read the Daytona docs and learn how to use it”
+
+**Where to put it (in priority order):**
+
+1. **Project-local (recommended):** `<repo>/.agents/skills/<skill-name>/SKILL.md`
+2. **User-global:** `~/.agents/skills/<skill-name>/SKILL.md`
+
+Notes:
+- **Project skills override user + public skills** (same `name`). This is the simplest way to “patch” a public skill locally.
+- Add `triggers:` only when you really want automatic activation; prefer **distinctive phrases** to avoid injecting the skill on unrelated messages.
+
+See: [Templates](references/TEMPLATES.md#agentskillsskillmd-template).
+
+### 1.2 Add always-on repo instructions (AGENTS.md)
+
+Use when the user wants **always-applied** guidance for a repository (style, commands, guardrails, conventions):
+
+- Create or edit `<repo>/AGENTS.md` (or model-specific variants like `CLAUDE.md`, `GEMINI.md` if your environment supports them).
+- Put the repo rules there.
+
+This gets loaded at conversation start as “always-on context” (not progressive disclosure).
+
+### 1.3 Add hooks (policy/automation) via `.openhands/hooks.json`
+
+Use when the user wants **enforcement** or **automation** around tool usage, e.g.:
+- “Before any git commit, run tests.”
+- “Block any command that tries to access prod without approval.”
+- “Reject tool calls that write outside the repo.”
+
+Hooks are executed on lifecycle events (like `pre_tool_use`) and can **allow / block / modify** actions.
+
+See: [Hook templates](references/TEMPLATES.md#hookshooksjson-template) and [Hook architecture notes](references/ARCHITECTURE.md#hooks).
+
+### 1.4 Add tools via MCP (`.mcp.json`)
+
+Recommend MCP **only when there is a concrete MCP server to add**:
+
+- The user explicitly asks to “add an MCP server”, **or**
+- The user asks for a capability and you can point to an existing MCP server for it (e.g., from that project’s docs / an official MCP server repo).
+
+If there isn’t an MCP server available for what they want, don’t force MCP:
+- start with a **skill** (instructions/workflow), or
+- if they truly need a new tool, the real work item is to **build or install an MCP server** (or implement a native tool/code change).
+
+MCP server configuration location **depends on the runtime**:
+
+- **OpenHands-CLI** persists MCP servers in `~/.openhands/mcp.json` (or `$OPENHANDS_PERSISTENCE_DIR/mcp.json`).
+- **Software Agent SDK skills/plugins** use a **per-skill/per-plugin** `.mcp.json` file located inside the skill/plugin directory.
+
+See: [MCP template](references/TEMPLATES.md#mcp-template).
+
+### 1.5 Package it as a plugin (shareable bundle)
+
+Use when the change should be **portable** across repos or shared with others, and it includes more than just instructions:
+- skills + hooks + MCP config together
+- optional slash commands and/or specialized agents
+
+Plugins follow the Claude Code-compatible structure, with `.plugin/plugin.json` (or `.claude-plugin/plugin.json`).
+
+See: [Plugin template](references/TEMPLATES.md#plugin-template) and [Plugin architecture notes](references/ARCHITECTURE.md#plugins).
+
+## 2) When code changes are actually required
+
+Choose the correct codebase / package:
+
+- **CLI UX, TUI widgets, slash commands, config files** → `OpenHands/OpenHands-CLI`
+- **Agent runtime logic, skill loading, hooks system, plugin loader, event model** → `OpenHands/software-agent-sdk` → `openhands-sdk`
+- **Built-in tools (Terminal, File Editor, Task Tracker, etc.)** → `OpenHands/software-agent-sdk` → `openhands-tools`
+- **Workspace mounting / file sync / workspace abstraction** → `OpenHands/software-agent-sdk` → `openhands-workspace`
+
+If you’re not sure, start by reproducing the issue and locating the code path.
+
+## 3) uv development workflows (including `uv tool install openhands`)
+
+- If they run OpenHands from a **local clone**: use `uv sync` + `uv run openhands`.
+- If they installed OpenHands via **`uv tool install openhands`**:
+  - safest: `uv tool run --from /path/to/OpenHands-CLI openhands`
+  - persistent: `uv tool install --force --editable /path/to/OpenHands-CLI`
+- If they need to modify the **SDK** while running the CLI, remember: the CLI often **pins exact SDK/tool versions**. Prefer aligning versions; use overrides only for local development.
+
+Details: [Installation modes (`uv tool` vs `uv run`)](references/INSTALLATION_MODES.md).
+
+## 4) What requires a restart to take effect?
+
+- **Skills / AGENTS.md**: loaded at conversation start → usually **start a new conversation** to pick them up. Ask the user to fully restart OpenHands only if needed.
+- **Hooks (.openhands/hooks.json)**: loaded when the agent/conversation initializes → ask the user to restart (or create a fresh session) to guarantee reload.
+- **Plugins**: loaded when the conversation initializes → ask the user to restart (or create a fresh session) to guarantee reload.
+- **Editable Python code (uv tool `--editable` or local `uv run`)**: changes apply the next time the Python process starts → ask the user to restart the CLI/app.
+
+## 5) Verification checklist
+
+After making a “self-modification” change, guide the **user** through verification:
+
+1. Ask the user to start a **fresh conversation** (and restart OpenHands only if needed).
+2. If they’re using the **OpenHands CLI TUI**, ask them to type `/skills` to confirm the expected skills/hooks/MCPs are loaded.
+3. Ask the user to send a tiny, deterministic **test prompt** that should trigger the new behavior.
+4. If it’s a code change, run the smallest relevant test suite (or ask the user to run it) and confirm the behavior matches.
+
+## References
+
+- [Architecture: CLI vs SDK vs skills/hooks/plugins](references/ARCHITECTURE.md)
+- [Installation modes: `uv tool` vs `uv run` and version pinning](references/INSTALLATION_MODES.md)
+- [Templates: SKILL.md, hooks.json, plugin.json, .mcp.json](references/TEMPLATES.md)

--- a/skills/adapt-yourself/references/ARCHITECTURE.md
+++ b/skills/adapt-yourself/references/ARCHITECTURE.md
@@ -1,0 +1,101 @@
+# OpenHands extensibility architecture (CLI + SDK)
+
+OpenHands “behavior” can be modified at multiple layers. The key is to choose the layer that matches the user’s intent.
+
+## Components
+
+### OpenHands CLI (`OpenHands/OpenHands-CLI`)
+
+- Python package name: `openhands`
+- Entry points: `openhands`, `openhands-acp`
+- Responsibilities:
+  - Terminal UI (Textual)
+  - Loading config + wiring up an SDK `Agent`
+  - Choosing tools and building an `AgentContext`
+
+In the CLI codebase, look for where it creates the `AgentContext` and enables:
+- project skills
+- user skills
+- public skills
+
+### Software Agent SDK monorepo (`OpenHands/software-agent-sdk`)
+
+This repo is a **uv workspace** that produces multiple packages:
+
+- `openhands-sdk` (module: `openhands.sdk`)
+  - agent runtime primitives (Agent, Conversation, Event model)
+  - context loading (skills)
+  - hooks system
+  - plugin loader
+
+- `openhands-tools` (module: `openhands.tools`)
+  - built-in tools used by many OpenHands projects
+
+- `openhands-workspace` (module: `openhands.workspace`)
+  - workspace mounting, file sync abstractions
+
+- `openhands-agent-server`
+  - server-side runtime
+
+## Skills
+
+Skills are loaded from multiple locations; **project-local skills override user + public**.
+
+Common locations:
+
+- Project-local:
+  - `<repo>/.agents/skills/`
+
+- User-global:
+  - `~/.agents/skills/`
+
+- Public registry:
+  - `https://github.com/OpenHands/extensions` (cached locally under `~/.openhands/skills-cache/`)
+
+Skill types:
+
+- **AgentSkills format**: a directory with `SKILL.md` (progressive disclosure)
+- **Always-on instructions**: repo instruction files like `AGENTS.md` (loaded at conversation start)
+
+## Hooks
+
+Hooks are configured via JSON and executed on events (e.g. `pre_tool_use`).
+
+Typical locations (depending on project / SDK config):
+
+- `<repo>/.openhands/hooks.json`
+- `~/.openhands/hooks.json`
+
+Hook scripts receive an event payload on stdin as JSON and respond with a decision.
+
+## Plugins
+
+Plugins are bundles of:
+
+- skills
+- hooks
+- MCP config
+- optional commands and agents
+
+They follow the Claude Code-compatible directory structure:
+
+```
+my-plugin/
+├── .plugin/
+│   └── plugin.json
+├── skills/
+├── hooks/
+│   └── hooks.json
+├── .mcp.json
+└── README.md
+```
+
+Plugins can be:
+- loaded from a local path
+- fetched from GitHub/git URLs and cached under `~/.openhands/cache/plugins/`
+
+## MCP servers (tools)
+
+MCP servers provide tool endpoints to the agent.
+
+They are configured via `.mcp.json` (location depends on host project). Plugins can also provide MCP config.

--- a/skills/adapt-yourself/references/INSTALLATION_MODES.md
+++ b/skills/adapt-yourself/references/INSTALLATION_MODES.md
@@ -1,0 +1,114 @@
+# Installation and development modes (uv)
+
+This reference is for making “persistent self-modifications” that apply after restart.
+
+## `uv run` (project environment) mode
+
+Use when you are developing from a git clone.
+
+- `uv sync` installs dependencies into a project-local `.venv/` (and/or uses the uv lockfile).
+- `uv run ...` runs inside that environment.
+
+Typical CLI dev flow:
+
+```bash
+cd OpenHands-CLI
+uv sync --group dev
+uv run openhands
+```
+
+Typical SDK dev flow:
+
+```bash
+cd software-agent-sdk
+uv sync --group dev
+uv run pytest
+```
+
+### Pros
+
+- Simple debugging (local sources)
+- Easy to run tests + linters
+- No global tool replacement needed
+
+### Cons
+
+- You must run `openhands` via `uv run openhands` (or ensure the venv is on PATH)
+
+## `uv tool install openhands` (tool environment) mode
+
+In this mode, `uv` installs the CLI into a dedicated tool environment and exposes a shim executable.
+
+### Inspect installed tools
+
+```bash
+uv tool list
+uv tool dir
+```
+
+If `openhands` is installed and not found on PATH, run:
+
+```bash
+uv tool update-shell
+```
+
+### Replace the tool with an editable local checkout
+
+This is the most common way to run a modified CLI *after restart*:
+
+```bash
+uv tool install --force --editable /path/to/OpenHands-CLI
+```
+
+After that, `openhands` should use the editable sources.
+
+### Run a local checkout without installing
+
+This is the safest way to test a change:
+
+```bash
+uv tool run --from /path/to/OpenHands-CLI openhands
+```
+
+## SDK vs CLI version pins
+
+The CLI often pins exact versions of:
+
+- `openhands-sdk`
+- `openhands-tools`
+- `openhands-workspace`
+
+If you want to use a local SDK checkout *together with the CLI*, you must handle that pinning.
+
+### What usually works
+
+1. Check the versions the CLI requires:
+   - `OpenHands-CLI/pyproject.toml`
+2. Check out the matching tag/commit in `software-agent-sdk`.
+3. Install the matching SDK packages in editable mode into the environment that runs the CLI.
+
+### What commonly fails
+
+Trying to install an SDK checkout at version `X` into an environment where the CLI requires `openhands-sdk==Y`.
+
+### Using `--overrides` for development
+
+As a last resort for local development, you can override pinned deps.
+
+Create a file (e.g. `overrides.txt`) containing a direct URL or local path spec:
+
+```text
+openhands-sdk @ file:///absolute/path/to/software-agent-sdk/openhands-sdk
+openhands-tools @ file:///absolute/path/to/software-agent-sdk/openhands-tools
+openhands-workspace @ file:///absolute/path/to/software-agent-sdk/openhands-workspace
+```
+
+Then install the CLI tool using that overrides file:
+
+```bash
+uv tool install --force --editable /path/to/OpenHands-CLI --overrides overrides.txt
+```
+
+Notes:
+- This is intentionally “break glass”; it can produce a mismatched runtime.
+- Prefer aligning versions whenever possible.

--- a/skills/adapt-yourself/references/TEMPLATES.md
+++ b/skills/adapt-yourself/references/TEMPLATES.md
@@ -1,0 +1,156 @@
+# Templates
+
+Use these as starting points when implementing a “self-modification” without changing OpenHands code.
+
+## AgentSkills (`SKILL.md`) template
+
+If you decide an Agentskill is appropriate for user's request to remember or adapt to their needs, you can create it. First, create a directory:
+
+```
+<repo>/.agents/skills/<skill-name>/
+└── SKILL.md
+```
+
+Example `SKILL.md`:
+
+```md
+---
+name: my-team-workflow
+description: Our team’s workflow for X. Use when the user asks about X.
+triggers:
+- team x workflow
+- how do we do x
+---
+
+# Our workflow for X
+
+## When to use
+
+Use this workflow when...
+
+## Steps
+
+1. ...
+2. ...
+
+## Verification
+
+- Run: `...`
+```
+
+Notes:
+- Keep triggers distinctive.
+- Keep the file focused; put deep details in `references/`.
+
+## Always-on repo instructions (`AGENTS.md`) template
+
+Create `<repo>/AGENTS.md`:
+
+```md
+# Project rules
+
+## Build / run
+- `make install`
+- `make test`
+
+## Code style
+- Ruff formatting
+
+## Safety
+- Never run destructive commands without asking
+```
+
+## Hooks (`.openhands/hooks.json`) template
+
+If you decide a Hook is appropriate for addressing the user's request to adapt for next time, you can create a hook. Create or use `<repo>/.openhands/hooks.json`:
+
+```json
+{
+  "pre_tool_use": [
+    {
+      "command": "bash .openhands/hooks/block-dangerous.sh",
+      "matchers": {
+        "tool_name": "terminal"
+      }
+    }
+  ]
+}
+```
+
+Then create the script `<repo>/.openhands/hooks/block-dangerous.sh`:
+
+```bash
+#!/usr/bin/env bash
+
+# stdin: HookEvent JSON
+payload="$(cat)"
+
+# Example: block `rm -rf ...` for Terminal tool calls.
+# Requires: jq
+cmd="$(echo "$payload" | jq -r '.tool_input.command // ""')"
+
+if echo "$cmd" | grep -Eq '(^|[[:space:]])rm[[:space:]]+-rf([[:space:]]|$)'; then
+  # HookExecutor parses JSON on stdout; "decision" must be "allow" or "deny".
+  jq -n --arg reason "Blocked destructive command" '{"decision":"deny","reason":$reason}'
+  exit 0
+fi
+
+jq -n '{"decision":"allow"}'
+```
+
+Notes:
+- Prefer parsing the structured fields (like `.tool_input.command`) rather than grepping raw JSON.
+- The exact `tool_input` shape is tool-specific; inspect the SDK `HookEvent` schema and your tool inputs.
+
+## Plugin template
+
+Plugin structure:
+
+```
+my-plugin/
+├── .plugin/
+│   └── plugin.json
+├── skills/
+│   └── my-skill/
+│       └── SKILL.md
+├── hooks/
+│   └── hooks.json
+├── .mcp.json
+└── README.md
+```
+
+Minimal `.plugin/plugin.json` (fields vary by plugin schema):
+
+```json
+{
+  "name": "my-plugin",
+  "version": "0.1.0",
+  "description": "My custom OpenHands behavior",
+  "author": {
+    "name": "Example",
+    "email": "dev@example.com"
+  }
+}
+```
+
+## MCP template (`.mcp.json`)
+
+Minimal example:
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "command": "python",
+      "args": ["-m", "my_mcp_server"],
+      "env": {
+        "MY_SERVER_TOKEN": "$MY_SERVER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+Notes:
+- Never hardcode real secrets in files.
+- Prefer environment variables.

--- a/skills/babysit-pr/README.md
+++ b/skills/babysit-pr/README.md
@@ -1,0 +1,19 @@
+# babysit-pr
+
+Babysit a GitHub pull request by monitoring CI checks/workflow runs, review comments, and mergeability until the PR is ready to merge (or merged/closed).
+
+## Triggers
+
+This skill is activated by:
+
+- `/babysit-pr`
+- `/babysit`
+- the agent may activate it if it needs to “babysit PR”, “watch PR”, “monitor CI”, or “check GitHub Actions”
+
+## Details
+
+- Requires the GitHub CLI (`gh`) to be available and authenticated.
+- Uses `scripts/gh_pr_watch.py` to emit one-shot snapshots (`--once`) or a continuous JSONL stream (`--watch`).
+- The watcher can surface review comments from approved review bots by matching keywords in the bot login.
+  - Defaults include: `openhands`, `openhands-agent`, `all-hands-bot`, `smolpaws`, `claude`, `codex`.
+  - Optional: set `BABYSIT_PR_REVIEW_BOT_KEYWORDS` (comma-separated) to allow additional bot keywords.

--- a/skills/babysit-pr/SKILL.md
+++ b/skills/babysit-pr/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: babysit-pr
+description: Babysit a GitHub pull request by continuously polling CI checks/workflow runs, new review comments, and mergeability state until the PR is ready to merge (or merged/closed). Diagnose failures, retry likely flaky failures up to 3 times, fix/push branch-related issues when appropriate, and stop only when user help is required (e.g., CI infrastructure outages, exhausted flaky retries, permissions, or ambiguous/blocking situations). Use when the user asks to monitor/watch/babysit a PR, watch CI, handle review comments, or keep an eye on mergeability.
+triggers:
+- /babysit-pr
+- /babysit
+---
+
+# PR Babysitter
+
+## Objective
+Babysit a PR persistently until one of these terminal outcomes occurs:
+
+- The PR is merged or closed.
+- CI is successful, there are no unaddressed review comments surfaced by the watcher, required review approval is not blocking merge, and there are no potential merge conflicts (PR is mergeable / not reporting conflict risk).
+- A situation requires user help (for example CI infrastructure issues, repeated flaky failures after retry budget is exhausted, permission problems, or ambiguity that cannot be resolved safely).
+
+Do not stop merely because a single snapshot returns `idle` while checks are still pending.
+
+## Inputs
+Accept any of the following:
+
+- No PR argument: infer the PR from the current branch (`--pr auto`)
+- PR number
+- PR URL
+
+## Core Workflow
+
+1. When the user asks to "monitor"/"watch"/"babysit" a PR, start with the watcher's continuous mode (`--watch`) unless you are intentionally doing a one-shot diagnostic snapshot.
+2. Run the watcher script to snapshot PR/CI/review state (or consume each streamed snapshot from `--watch`).
+3. Inspect the `actions` list in the JSON response.
+4. If `diagnose_ci_failure` is present, inspect failed run logs and classify the failure.
+5. If the failure is likely caused by the current branch, patch code locally, commit, and push.
+6. If `process_review_comment` is present, inspect surfaced review items and decide whether to address them.
+7. If a review item is actionable and correct, patch code locally, commit, and push.
+8. If the failure is likely flaky/unrelated and `retry_failed_checks` is present, rerun failed jobs with `--retry-failed-now`.
+9. If both actionable review feedback and `retry_failed_checks` are present, prioritize review feedback first; a new commit will retrigger CI, so avoid rerunning flaky checks on the old SHA unless you intentionally defer the review change.
+10. On every loop, verify mergeability / merge-conflict status (for example via `gh pr view`) in addition to CI and review state.
+11. After any push or rerun action, immediately return to step 1 and continue polling on the updated SHA/state.
+12. If you had been using `--watch` before pausing to patch/commit/push, relaunch `--watch` yourself in the same turn immediately after the push (do not wait for the user to re-invoke the skill).
+13. Repeat polling until the PR is green + review-clean + mergeable, `stop_pr_closed` appears, or a user-help-required blocker is reached.
+14. Maintain terminal/session ownership: while babysitting is active, keep consuming watcher output in the same turn; do not leave a detached `--watch` process running and then end the turn as if monitoring were complete.
+
+## Commands
+
+### One-shot snapshot
+
+```bash
+python3 <this-skill-path>/scripts/gh_pr_watch.py --pr auto --once
+```
+
+### Continuous watch (JSONL)
+
+```bash
+python3 <this-skill-path>/scripts/gh_pr_watch.py --pr auto --watch
+```
+
+### Trigger flaky retry cycle (only when watcher indicates)
+
+```bash
+python3 <this-skill-path>/scripts/gh_pr_watch.py --pr auto --retry-failed-now
+```
+
+### Explicit PR target
+
+```bash
+python3 <this-skill-path>/scripts/gh_pr_watch.py --pr <number-or-url> --once
+```
+
+## CI Failure Classification
+Use `gh` commands to inspect failed runs before deciding to rerun.
+
+- `gh run view <run-id> --json jobs,name,workflowName,conclusion,status,url,headSha`
+- `gh run view <run-id> --log-failed`
+
+Prefer treating failures as branch-related when logs point to changed code (compile/test/lint/typecheck/snapshots/static analysis in touched areas).
+
+Prefer treating failures as flaky/unrelated when logs show transient infra/external issues (timeouts, runner provisioning failures, registry/network outages, GitHub Actions infra errors).
+
+If classification is ambiguous, perform one manual diagnosis attempt before choosing rerun.
+
+Read `references/heuristics.md` for a concise checklist.
+
+## Review Comment Handling
+The watcher surfaces review items from:
+
+- PR issue comments
+- Inline review comments
+- Review submissions (COMMENT / APPROVED / CHANGES_REQUESTED)
+
+It can also surface feedback from approved review bots (configured in `scripts/gh_pr_watch.py`) in addition to human reviewer feedback. Ignore unrelated bot noise.
+For safety, the watcher only auto-surfaces trusted human review authors (OWNER/MEMBER/COLLABORATOR, plus the authenticated operator) and approved review bots.
+On a fresh watcher state file, existing pending review feedback may be surfaced immediately (not only comments that arrive after monitoring starts). This is intentional so already-open review comments are not missed.
+
+When you agree with a comment and it is actionable:
+
+1. Patch code locally.
+2. Commit with `chore: address PR review feedback (#<n>)`.
+3. Push to the PR head branch.
+4. Resume watching on the new SHA immediately (do not stop after reporting the push).
+5. If monitoring was running in `--watch` mode, restart `--watch` immediately after the push in the same turn; do not wait for the user to ask again.
+
+If you disagree or the comment is non-actionable/already addressed, record it as handled by continuing the watcher loop (the script de-duplicates surfaced items via state after surfacing them).
+If a code review comment/thread is already marked as resolved in GitHub, treat it as non-actionable and safely ignore it unless new unresolved follow-up feedback appears.
+
+## Optional: Request (Re-)Review
+
+If the PR is green/mergeable but blocked on approval (for example `reviewDecision` is `REVIEW_REQUIRED` or `CHANGES_REQUESTED`) and you believe you’ve addressed all surfaced feedback, you can request another look.
+
+Rules:
+
+- Only do this when the user explicitly asks you to request review / ping reviewers, or after confirming with the user (avoid spamming humans).
+- Prefer requesting review only once per new head SHA.
+- If permissions fail or it’s unclear who should review, stop and ask the user.
+
+Suggested flow:
+
+1. Leave a brief PR comment summarizing what changed and why re-review is needed.
+   ```bash
+   gh pr comment <pr> --body "Addressed the requested changes in <sha>. Could you take another look?"
+   ```
+   Do NOT tag humans.
+2. Re-request reviewers via the GitHub API.
+   ```bash
+   gh api -X POST repos/<owner>/<repo>/pulls/<pr_number>/requested_reviewers \
+     -f reviewers[]=reviewer1 \
+     -f reviewers[]=reviewer2
+   # For team reviewers:
+   #   -f team_reviewers[]=my-team
+   ```
+
+If the API returns an error indicating reviewers are already requested, treat it as non-fatal and continue monitoring.
+
+
+## Git Safety Rules
+
+- Work only on the PR head branch.
+- Avoid destructive git commands.
+- Do not switch branches unless necessary to recover context.
+- Before editing, check for unrelated uncommitted changes. If present, stop and ask the user.
+- After each successful fix, commit and `git push`, then re-run the watcher.
+- If you interrupted a live `--watch` session to make the fix, restart `--watch` immediately after the push in the same turn.
+- Do not run multiple concurrent `--watch` processes for the same PR/state file; keep one watcher session active and reuse it until it stops or you intentionally restart it.
+- A push is not a terminal outcome; continue the monitoring loop unless a strict stop condition is met.
+
+Commit message defaults:
+
+- `fix: CI failure on PR #<n>`
+- `chore: address PR review feedback (#<n>)`
+
+## Monitoring Loop Pattern
+Use this loop in a live OpenHands session:
+
+1. Run `--once`.
+2. Read `actions`.
+3. First check whether the PR is now merged or otherwise closed; if so, report that terminal state and stop polling immediately.
+4. Check CI summary, new review items, and mergeability/conflict status.
+5. Diagnose CI failures and classify branch-related vs flaky/unrelated.
+6. Process actionable review comments before flaky reruns when both are present; if a review fix requires a commit, push it and skip rerunning failed checks on the old SHA.
+7. Retry failed checks only when `retry_failed_checks` is present and you are not about to replace the current SHA with a review/CI fix commit.
+8. If you pushed a commit or triggered a rerun, report the action briefly and continue polling (do not stop).
+9. After a review-fix push, proactively restart continuous monitoring (`--watch`) in the same turn unless a strict stop condition has already been reached.
+10. If everything is passing, mergeable, not blocked on required review approval, and there are no unaddressed review items, report success and stop.
+11. If blocked on a user-help-required issue (infra outage, exhausted flaky retries, unclear reviewer request, permissions), report the blocker and stop.
+12. Otherwise sleep according to the polling cadence below and repeat.
+
+When the user explicitly asks to monitor/watch/babysit a PR, prefer `--watch` so polling continues autonomously in one command. Use repeated `--once` snapshots only for debugging, local testing, or when the user explicitly asks for a one-shot check.
+Do not stop to ask the user whether to continue polling; continue autonomously until a strict stop condition is met or the user explicitly interrupts.
+Do not hand control back to the user after a review-fix push just because a new SHA was created; restarting the watcher and re-entering the poll loop is part of the same babysitting task.
+If a `--watch` process is still running and no strict stop condition has been reached, the babysitting task is still in progress; keep streaming/consuming watcher output instead of ending the turn.
+
+## Polling Cadence
+Use adaptive polling and continue monitoring even after CI turns green:
+
+- While CI is not green (pending/running/queued or failing): poll every 1 minute.
+- After CI turns green: start at every 1 minute, then back off exponentially when there is no change (for example 1m, 2m, 4m, 8m, 16m, 32m), capping at every 1 hour.
+- Reset the green-state polling interval back to 1 minute whenever anything changes (new commit/SHA, check status changes, new review comments, mergeability changes, review decision changes).
+- If CI stops being green again (new commit, rerun, or regression): return to 1-minute polling.
+- If any poll shows the PR is merged or otherwise closed: stop polling immediately and report the terminal state.
+
+## Stop Conditions (Strict)
+Stop only when one of the following is true:
+
+- PR merged or closed (stop as soon as a poll/snapshot confirms this).
+- PR is ready to merge: CI succeeded, no surfaced unaddressed review comments, not blocked on required review approval, and no merge conflict risk.
+- User intervention is required and the agent cannot safely proceed alone.
+
+Keep polling when:
+
+- `actions` contains only `idle` but checks are still pending.
+- CI is still running/queued.
+- Review state is quiet but CI is not terminal.
+- CI is green but mergeability is unknown/pending.
+- CI is green and mergeable, but the PR is still open and you are waiting for possible new review comments or merge-conflict changes per the green-state cadence.
+- The PR is green but blocked on review approval (`REVIEW_REQUIRED` / similar); continue polling on the green-state cadence and surface any new review comments without asking for confirmation to keep watching.
+
+## Output Expectations
+Provide concise progress updates while monitoring and a final summary that includes:
+
+- During long unchanged monitoring periods, avoid emitting a full update on every poll; summarize only status changes plus occasional heartbeat updates.
+- Treat push confirmations, intermediate CI snapshots, and review-action updates as progress updates only; do not emit the final summary or end the babysitting session unless a strict stop condition is met.
+- A user request to "monitor" is not satisfied by a couple of sample polls; remain in the loop until a strict stop condition or an explicit user interruption.
+- A review-fix commit + push is not a completion event; immediately resume live monitoring (`--watch`) in the same turn and continue reporting progress updates.
+- When CI first transitions to all green for the current SHA, emit a one-time celebratory progress update (do not repeat it on every green poll). Preferred style: `🚀 CI is all green! 33/33 passed. Still on watch for review approval.`
+- Do not send the final summary while a watcher terminal is still running unless the watcher has emitted/confirmed a strict stop condition; otherwise continue with progress updates.
+
+- Final PR SHA
+- CI status summary
+- Mergeability / conflict status
+- Fixes pushed
+- Flaky retry cycles used
+- Remaining unresolved failures or review comments
+
+## References
+
+- Heuristics and decision tree: `references/heuristics.md`
+- GitHub CLI/API details used by the watcher: `references/github-api-notes.md`

--- a/skills/babysit-pr/references/github-api-notes.md
+++ b/skills/babysit-pr/references/github-api-notes.md
@@ -1,0 +1,72 @@
+# GitHub CLI / API Notes For `babysit-pr`
+
+## Primary commands used
+
+### PR metadata
+
+- `gh pr view --json number,url,state,mergedAt,closedAt,headRefName,headRefOid,headRepository,headRepositoryOwner`
+
+Used to resolve PR number, URL, branch, head SHA, and closed/merged state.
+
+### PR checks summary
+
+- `gh pr checks --json name,state,bucket,link,workflow,event,startedAt,completedAt`
+
+Used to compute pending/failed/passed counts and whether the current CI round is terminal.
+
+### Workflow runs for head SHA
+
+- `gh api repos/{owner}/{repo}/actions/runs -X GET -f head_sha=<sha> -f per_page=100`
+
+Used to discover failed workflow runs and rerunnable run IDs.
+
+### Failed log inspection
+
+- `gh run view <run-id> --json jobs,name,workflowName,conclusion,status,url,headSha`
+- `gh run view <run-id> --log-failed`
+
+Used by the agent to classify branch-related vs flaky/unrelated failures.
+
+### Retry failed jobs only
+
+- `gh run rerun <run-id> --failed`
+
+Reruns only failed jobs (and dependencies) for a workflow run.
+
+## Review-related endpoints
+
+- Issue comments on PR:
+  - `gh api repos/{owner}/{repo}/issues/<pr_number>/comments?per_page=100`
+- Inline PR review comments:
+  - `gh api repos/{owner}/{repo}/pulls/<pr_number>/comments?per_page=100`
+- Review submissions:
+  - `gh api repos/{owner}/{repo}/pulls/<pr_number>/reviews?per_page=100`
+
+## JSON fields consumed by the watcher
+
+### `gh pr view`
+
+- `number`
+- `url`
+- `state`
+- `mergedAt`
+- `closedAt`
+- `headRefName`
+- `headRefOid`
+
+### `gh pr checks`
+
+- `bucket` (`pass`, `fail`, `pending`, `skipping`)
+- `state`
+- `name`
+- `workflow`
+- `link`
+
+### Actions runs API (`workflow_runs[]`)
+
+- `id`
+- `name`
+- `status`
+- `conclusion`
+- `html_url`
+- `head_sha`

--- a/skills/babysit-pr/references/heuristics.md
+++ b/skills/babysit-pr/references/heuristics.md
@@ -1,0 +1,58 @@
+# CI / Review Heuristics
+
+## CI classification checklist
+
+Treat as **branch-related** when logs clearly indicate a regression caused by the PR branch:
+
+- Compile/typecheck/lint failures in files or modules touched by the branch
+- Deterministic unit/integration test failures in changed areas
+- Snapshot output changes caused by UI/text changes in the branch
+- Static analysis violations introduced by the latest push
+- Build script/config changes in the PR causing a deterministic failure
+
+Treat as **likely flaky or unrelated** when evidence points to transient or external issues:
+
+- DNS/network/registry timeout errors while fetching dependencies
+- Runner image provisioning or startup failures
+- GitHub Actions infrastructure/service outages
+- Cloud/service rate limits or transient API outages
+- Non-deterministic failures in unrelated integration tests with known flake patterns
+
+If uncertain, inspect failed logs once before choosing rerun.
+
+## Decision tree (fix vs rerun vs stop)
+
+1. If PR is merged/closed: stop.
+2. If there are failed checks:
+   - Diagnose first.
+   - If branch-related: fix locally, commit, push.
+   - If likely flaky/unrelated and all checks for the current SHA are terminal: rerun failed jobs.
+   - If checks are still pending: wait.
+3. If flaky reruns for the same SHA reach the configured limit (default 3): stop and report persistent failure.
+4. Independently, process any new human review comments.
+
+## Review comment agreement criteria
+
+Address the comment when:
+
+- The comment is technically correct.
+- The change is actionable in the current branch.
+- The requested change does not conflict with the user’s intent or recent guidance.
+- The change can be made safely without unrelated refactors.
+
+Do not auto-fix when:
+
+- The comment is ambiguous and needs clarification.
+- The request conflicts with explicit user instructions.
+- The proposed change requires product/design decisions the user has not made.
+- The codebase is in a dirty/unrelated state that makes safe editing uncertain.
+
+## Stop-and-ask conditions
+
+Stop and ask the user instead of continuing automatically when:
+
+- The local worktree has unrelated uncommitted changes.
+- `gh` auth/permissions fail.
+- The PR branch cannot be pushed.
+- CI failures persist after the flaky retry budget.
+- Reviewer feedback requires a product decision or cross-team coordination.

--- a/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -1,0 +1,886 @@
+#!/usr/bin/env python3
+"""Watch GitHub PR CI and review activity for PR babysitting workflows."""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from urllib.parse import urlparse
+
+FAILED_RUN_CONCLUSIONS = {
+    "failure",
+    "timed_out",
+    "cancelled",
+    "action_required",
+    "startup_failure",
+    "stale",
+}
+PENDING_CHECK_STATES = {
+    "QUEUED",
+    "IN_PROGRESS",
+    "PENDING",
+    "WAITING",
+    "REQUESTED",
+}
+DEFAULT_REVIEW_BOT_LOGIN_KEYWORDS = [
+    "openhands",
+    "openhands-agent",
+    "all-hands-bot",
+    "smolpaws",
+    "claude",
+    "codex",
+]
+
+
+def normalize_review_bot_match_key(value: str, *, strip_bot_suffix: bool = False) -> str:
+    """Normalize review-bot logins/keywords so hyphen/underscore variants match."""
+
+    lower = (value or "").strip().lower()
+    if strip_bot_suffix and lower.endswith("[bot]"):
+        lower = lower[: -len("[bot]")]
+    return lower.replace("-", "_")
+
+
+def normalize_review_bot_keyword(value: str) -> str:
+    # Strip an optional `[bot]` suffix so users can pass either `foo-bot` or
+    # `foo-bot[bot]` via BABYSIT_PR_REVIEW_BOT_KEYWORDS.
+    return normalize_review_bot_match_key(value, strip_bot_suffix=True)
+
+
+_REVIEW_BOT_KEYWORDS_ENV = os.getenv("BABYSIT_PR_REVIEW_BOT_KEYWORDS", "")
+EXTRA_REVIEW_BOT_LOGIN_KEYWORDS = {
+    normalize_review_bot_keyword(kw)
+    for kw in _REVIEW_BOT_KEYWORDS_ENV.split(",")
+    if kw.strip()
+}
+REVIEW_BOT_LOGIN_KEYWORDS = {
+    normalize_review_bot_keyword(kw) for kw in DEFAULT_REVIEW_BOT_LOGIN_KEYWORDS
+} | EXTRA_REVIEW_BOT_LOGIN_KEYWORDS
+TRUSTED_AUTHOR_ASSOCIATIONS = {
+    "OWNER",
+    "MEMBER",
+    "COLLABORATOR",
+}
+MERGE_BLOCKING_REVIEW_DECISIONS = {
+    "REVIEW_REQUIRED",
+    "CHANGES_REQUESTED",
+}
+MERGE_CONFLICT_OR_BLOCKING_STATES = {
+    "BLOCKED",
+    "DIRTY",
+    "DRAFT",
+    "UNKNOWN",
+}
+GREEN_STATE_MAX_POLL_SECONDS = 60 * 60
+
+
+class GhCommandError(RuntimeError):
+    pass
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Normalize PR/CI/review state for PR babysitting and optionally "
+            "trigger flaky reruns."
+        )
+    )
+    parser.add_argument("--pr", default="auto", help="auto, PR number, or PR URL")
+    parser.add_argument("--repo", help="Optional OWNER/REPO override")
+    parser.add_argument("--poll-seconds", type=int, default=30, help="Watch poll interval")
+    parser.add_argument(
+        "--max-flaky-retries",
+        type=int,
+        default=3,
+        help="Max rerun cycles per head SHA before stop recommendation",
+    )
+    parser.add_argument("--state-file", help="Path to state JSON file")
+    parser.add_argument("--once", action="store_true", help="Emit one snapshot and exit")
+    parser.add_argument("--watch", action="store_true", help="Continuously emit JSONL snapshots")
+    parser.add_argument(
+        "--retry-failed-now",
+        action="store_true",
+        help="Rerun failed jobs for current failed workflow runs when policy allows",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable output (default behavior for --once and --retry-failed-now)",
+    )
+    args = parser.parse_args()
+
+    if args.poll_seconds <= 0:
+        parser.error("--poll-seconds must be > 0")
+    if args.max_flaky_retries < 0:
+        parser.error("--max-flaky-retries must be >= 0")
+    if args.watch and args.retry_failed_now:
+        parser.error("--watch cannot be combined with --retry-failed-now")
+    if not args.once and not args.watch and not args.retry_failed_now:
+        args.once = True
+    return args
+
+
+def _format_gh_error(cmd, err):
+    stdout = (err.stdout or "").strip()
+    stderr = (err.stderr or "").strip()
+    parts = [f"GitHub CLI command failed: {' '.join(cmd)}"]
+    if stdout:
+        parts.append(f"stdout: {stdout}")
+    if stderr:
+        parts.append(f"stderr: {stderr}")
+    return "\n".join(parts)
+
+
+def gh_text(args, repo=None):
+    cmd = ["gh"]
+    # `gh api` does not accept `-R/--repo` on all gh versions. The watcher's
+    # API calls use explicit endpoints (e.g. repos/{owner}/{repo}/...), so the
+    # repo flag is unnecessary there.
+    if repo and (not args or args[0] != "api"):
+        cmd.extend(["-R", repo])
+    cmd.extend(args)
+    try:
+        proc = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except FileNotFoundError as err:
+        raise GhCommandError("`gh` command not found") from err
+    except subprocess.CalledProcessError as err:
+        combined = f"{err.stdout or ''}\n{err.stderr or ''}".lower()
+        if "rate limit" in combined:
+            raise GhCommandError("GitHub API rate limit exceeded. Wait before retrying.") from err
+        raise GhCommandError(_format_gh_error(cmd, err)) from err
+    return proc.stdout
+
+
+def gh_json(args, repo=None):
+    raw = gh_text(args, repo=repo).strip()
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as err:
+        raise GhCommandError(f"Failed to parse JSON from gh output for {' '.join(args)}") from err
+
+
+def parse_pr_spec(pr_spec):
+    if pr_spec == "auto":
+        return {"mode": "auto", "value": None}
+    if re.fullmatch(r"\d+", pr_spec):
+        return {"mode": "number", "value": pr_spec}
+    parsed = urlparse(pr_spec)
+    if parsed.scheme and parsed.netloc and "/pull/" in parsed.path:
+        return {"mode": "url", "value": pr_spec}
+    raise ValueError("--pr must be 'auto', a PR number, or a PR URL")
+
+
+def pr_view_fields():
+    return (
+        "number,url,state,mergedAt,closedAt,headRefName,headRefOid,"
+        "headRepository,headRepositoryOwner,mergeable,mergeStateStatus,reviewDecision"
+    )
+
+
+def checks_fields():
+    return "name,state,bucket,link,workflow,event,startedAt,completedAt"
+
+
+def resolve_pr(pr_spec, repo_override=None):
+    parsed = parse_pr_spec(pr_spec)
+    cmd = ["pr", "view"]
+    if parsed["value"] is not None:
+        cmd.append(parsed["value"])
+    cmd.extend(["--json", pr_view_fields()])
+    data = gh_json(cmd, repo=repo_override)
+    if not isinstance(data, dict):
+        raise GhCommandError("Unexpected PR payload from `gh pr view`")
+
+    pr_url = str(data.get("url") or "")
+    repo = (
+        repo_override
+        or extract_repo_from_pr_url(pr_url)
+        or extract_repo_from_pr_view(data)
+    )
+    if not repo:
+        raise GhCommandError("Unable to determine OWNER/REPO for the PR")
+
+    state = str(data.get("state") or "")
+    merged = bool(data.get("mergedAt"))
+    closed = bool(data.get("closedAt")) or state.upper() == "CLOSED"
+
+    return {
+        "number": int(data["number"]),
+        "url": pr_url,
+        "repo": repo,
+        "head_sha": str(data.get("headRefOid") or ""),
+        "head_branch": str(data.get("headRefName") or ""),
+        "state": state,
+        "merged": merged,
+        "closed": closed,
+        "mergeable": str(data.get("mergeable") or ""),
+        "merge_state_status": str(data.get("mergeStateStatus") or ""),
+        "review_decision": str(data.get("reviewDecision") or ""),
+    }
+
+
+def extract_repo_from_pr_view(data):
+    head_repo = data.get("headRepository")
+    head_owner = data.get("headRepositoryOwner")
+    owner = None
+    name = None
+    if isinstance(head_owner, dict):
+        owner = head_owner.get("login") or head_owner.get("name")
+    elif isinstance(head_owner, str):
+        owner = head_owner
+    if isinstance(head_repo, dict):
+        name = head_repo.get("name")
+        repo_owner = head_repo.get("owner")
+        if not owner and isinstance(repo_owner, dict):
+            owner = repo_owner.get("login") or repo_owner.get("name")
+    elif isinstance(head_repo, str):
+        name = head_repo
+    if owner and name:
+        return f"{owner}/{name}"
+    return None
+
+
+def extract_repo_from_pr_url(pr_url):
+    parsed = urlparse(pr_url)
+    parts = [p for p in parsed.path.split("/") if p]
+    if len(parts) >= 4 and parts[2] == "pull":
+        return f"{parts[0]}/{parts[1]}"
+    return None
+
+
+def load_state(path):
+    if path.exists():
+        try:
+            data = json.loads(path.read_text())
+        except json.JSONDecodeError as err:
+            raise RuntimeError(f"State file is not valid JSON: {path}") from err
+        if not isinstance(data, dict):
+            raise RuntimeError(f"State file must contain an object: {path}")
+        return data, False
+    return {
+        "pr": {},
+        "started_at": None,
+        "last_seen_head_sha": None,
+        "retries_by_sha": {},
+        "seen_items": [],
+        "last_snapshot_at": None,
+    }, True
+
+
+def save_state(path, state):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(state, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(prefix=f"{path.name}.", suffix=".tmp", dir=path.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
+            tmp_file.write(payload)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def default_state_file_for(pr):
+    repo_slug = pr["repo"].replace("/", "-")
+    return Path(f"/tmp/openhands-babysit-pr-{repo_slug}-pr{pr['number']}.json")
+
+
+def get_pr_checks(pr_spec, repo):
+    parsed = parse_pr_spec(pr_spec)
+    cmd = ["pr", "checks"]
+    if parsed["value"] is not None:
+        cmd.append(parsed["value"])
+    cmd.extend(["--json", checks_fields()])
+    data = gh_json(cmd, repo=repo)
+    if data is None:
+        return []
+    if not isinstance(data, list):
+        raise GhCommandError("Unexpected payload from `gh pr checks`")
+    return data
+
+
+def is_pending_check(check):
+    bucket = str(check.get("bucket") or "").lower()
+    state = str(check.get("state") or "").upper()
+    return bucket == "pending" or state in PENDING_CHECK_STATES
+
+
+def summarize_checks(checks):
+    pending_count = 0
+    failed_count = 0
+    passed_count = 0
+    for check in checks:
+        bucket = str(check.get("bucket") or "").lower()
+        if is_pending_check(check):
+            pending_count += 1
+        if bucket == "fail":
+            failed_count += 1
+        if bucket == "pass":
+            passed_count += 1
+    return {
+        "pending_count": pending_count,
+        "failed_count": failed_count,
+        "passed_count": passed_count,
+        "all_terminal": pending_count == 0,
+    }
+
+
+def get_workflow_runs_for_sha(repo, head_sha):
+    endpoint = f"repos/{repo}/actions/runs"
+    data = gh_json(
+        ["api", endpoint, "-X", "GET", "-f", f"head_sha={head_sha}", "-f", "per_page=100"],
+        repo=repo,
+    )
+    if not isinstance(data, dict):
+        raise GhCommandError("Unexpected payload from actions runs API")
+    runs = data.get("workflow_runs") or []
+    if not isinstance(runs, list):
+        raise GhCommandError("Expected `workflow_runs` to be a list")
+    return runs
+
+
+def failed_runs_from_workflow_runs(runs, head_sha):
+    failed_runs = []
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        if str(run.get("head_sha") or "") != head_sha:
+            continue
+        conclusion = str(run.get("conclusion") or "")
+        if conclusion not in FAILED_RUN_CONCLUSIONS:
+            continue
+        failed_runs.append(
+            {
+                "run_id": run.get("id"),
+                "workflow_name": run.get("name") or run.get("display_title") or "",
+                "status": str(run.get("status") or ""),
+                "conclusion": conclusion,
+                "html_url": str(run.get("html_url") or ""),
+            }
+        )
+    failed_runs.sort(key=lambda item: (str(item.get("workflow_name") or ""), str(item.get("run_id") or "")))
+    return failed_runs
+
+
+_AUTHENTICATED_LOGIN_CACHE = None
+
+
+def get_authenticated_login():
+    global _AUTHENTICATED_LOGIN_CACHE
+    if _AUTHENTICATED_LOGIN_CACHE:
+        return _AUTHENTICATED_LOGIN_CACHE
+
+    data = gh_json(["api", "user"])
+    if not isinstance(data, dict) or not data.get("login"):
+        raise GhCommandError("Unable to determine authenticated GitHub login from `gh api user`")
+    _AUTHENTICATED_LOGIN_CACHE = str(data["login"])
+    return _AUTHENTICATED_LOGIN_CACHE
+
+
+def comment_endpoints(repo, pr_number):
+    return {
+        "issue_comment": f"repos/{repo}/issues/{pr_number}/comments",
+        "review_comment": f"repos/{repo}/pulls/{pr_number}/comments",
+        "review": f"repos/{repo}/pulls/{pr_number}/reviews",
+    }
+
+
+def gh_api_list_paginated(endpoint, repo=None, per_page=100):
+    items = []
+    page = 1
+    while True:
+        sep = "&" if "?" in endpoint else "?"
+        page_endpoint = f"{endpoint}{sep}per_page={per_page}&page={page}"
+        payload = gh_json(["api", page_endpoint], repo=repo)
+        if payload is None:
+            break
+        if not isinstance(payload, list):
+            raise GhCommandError(f"Unexpected paginated payload from gh api {endpoint}")
+        items.extend(payload)
+        if len(payload) < per_page:
+            break
+        page += 1
+    return items
+
+
+def normalize_issue_comments(items):
+    out = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        out.append(
+            {
+                "kind": "issue_comment",
+                "id": str(item.get("id") or ""),
+                "author": extract_login(item.get("user")),
+                "author_association": str(item.get("author_association") or ""),
+                "created_at": str(item.get("created_at") or ""),
+                "body": str(item.get("body") or ""),
+                "path": None,
+                "line": None,
+                "url": str(item.get("html_url") or ""),
+            }
+        )
+    return out
+
+
+def normalize_review_comments(items):
+    out = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        line = item.get("line")
+        if line is None:
+            line = item.get("original_line")
+        out.append(
+            {
+                "kind": "review_comment",
+                "id": str(item.get("id") or ""),
+                "author": extract_login(item.get("user")),
+                "author_association": str(item.get("author_association") or ""),
+                "created_at": str(item.get("created_at") or ""),
+                "body": str(item.get("body") or ""),
+                "path": item.get("path"),
+                "line": line,
+                "url": str(item.get("html_url") or ""),
+            }
+        )
+    return out
+
+
+def normalize_reviews(items):
+    out = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        out.append(
+            {
+                "kind": "review",
+                "id": str(item.get("id") or ""),
+                "author": extract_login(item.get("user")),
+                "author_association": str(item.get("author_association") or ""),
+                "created_at": str(item.get("submitted_at") or item.get("created_at") or ""),
+                "body": str(item.get("body") or ""),
+                "path": None,
+                "line": None,
+                "url": str(item.get("html_url") or ""),
+            }
+        )
+    return out
+
+
+def extract_login(user_obj):
+    if isinstance(user_obj, dict):
+        return str(user_obj.get("login") or "")
+    return ""
+
+
+# Alias - both normalize the same way (hyphen/underscore + optional [bot] suffix).
+normalize_review_bot_login = normalize_review_bot_keyword
+
+
+def is_bot_login(login):
+    return bool(login) and login.endswith("[bot]")
+
+
+def is_actionable_review_bot_login(login):
+    normalized = normalize_review_bot_login(login)
+    if not normalized:
+        return False
+    return any(keyword in normalized for keyword in REVIEW_BOT_LOGIN_KEYWORDS)
+
+
+def is_trusted_human_review_author(item, authenticated_login):
+    author = str(item.get("author") or "")
+    if not author:
+        return False
+    if authenticated_login and author == authenticated_login:
+        return True
+    association = str(item.get("author_association") or "").upper()
+    return association in TRUSTED_AUTHOR_ASSOCIATIONS
+
+
+def migrate_seen_items(state):
+    seen_items = {str(x) for x in state.get("seen_items") or []}
+
+    # Backwards-compatible migration from the older per-kind tracking lists.
+    for item_id in state.get("seen_issue_comment_ids") or []:
+        seen_items.add(f"issue_comment:{str(item_id)}")
+    for item_id in state.get("seen_review_comment_ids") or []:
+        seen_items.add(f"review_comment:{str(item_id)}")
+    for item_id in state.get("seen_review_ids") or []:
+        seen_items.add(f"review:{str(item_id)}")
+
+    state["seen_items"] = sorted(seen_items)
+    state.pop("seen_issue_comment_ids", None)
+    state.pop("seen_review_comment_ids", None)
+    state.pop("seen_review_ids", None)
+    return seen_items
+
+
+def fetch_new_review_items(pr, state, authenticated_login=None):
+    repo = pr["repo"]
+    pr_number = pr["number"]
+    endpoints = comment_endpoints(repo, pr_number)
+
+    issue_payload = gh_api_list_paginated(endpoints["issue_comment"], repo=repo)
+    review_comment_payload = gh_api_list_paginated(endpoints["review_comment"], repo=repo)
+    review_payload = gh_api_list_paginated(endpoints["review"], repo=repo)
+
+    issue_items = normalize_issue_comments(issue_payload)
+    review_comment_items = normalize_review_comments(review_comment_payload)
+    review_items = normalize_reviews(review_payload)
+    all_items = issue_items + review_comment_items + review_items
+
+    seen_items = migrate_seen_items(state)
+
+    # On a brand-new state file, surface existing review activity instead of
+    # silently treating it as seen. This avoids missing already-pending review
+    # feedback when monitoring starts after comments were posted.
+
+    new_items = []
+    for item in all_items:
+        item_id = item.get("id")
+        if not item_id:
+            continue
+        author = item.get("author") or ""
+        if not author:
+            continue
+        if is_actionable_review_bot_login(author):
+            pass
+        elif is_bot_login(author):
+            continue
+        elif not is_trusted_human_review_author(item, authenticated_login):
+            continue
+
+        kind = item["kind"]
+        key = f"{kind}:{item_id}"
+        if key in seen_items:
+            continue
+
+        new_items.append(item)
+        seen_items.add(key)
+
+    new_items.sort(
+        key=lambda item: (
+            item.get("created_at") or "",
+            item.get("kind") or "",
+            item.get("id") or "",
+        )
+    )
+
+    state["seen_items"] = sorted(seen_items)
+    return new_items
+
+
+def current_retry_count(state, head_sha):
+    retries = state.get("retries_by_sha") or {}
+    value = retries.get(head_sha, 0)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def set_retry_count(state, head_sha, count):
+    retries = state.get("retries_by_sha")
+    if not isinstance(retries, dict):
+        retries = {}
+    retries[head_sha] = int(count)
+    state["retries_by_sha"] = retries
+
+
+def unique_actions(actions):
+    out = []
+    seen = set()
+    for action in actions:
+        if action not in seen:
+            out.append(action)
+            seen.add(action)
+    return out
+
+
+def is_pr_ready_to_merge(pr, checks_summary, new_review_items):
+    if pr["closed"] or pr["merged"]:
+        return False
+    if not checks_summary["all_terminal"]:
+        return False
+    if checks_summary["failed_count"] > 0 or checks_summary["pending_count"] > 0:
+        return False
+    if new_review_items:
+        return False
+    if str(pr.get("mergeable") or "") != "MERGEABLE":
+        return False
+    if str(pr.get("merge_state_status") or "") in MERGE_CONFLICT_OR_BLOCKING_STATES:
+        return False
+    if str(pr.get("review_decision") or "") in MERGE_BLOCKING_REVIEW_DECISIONS:
+        return False
+    return True
+
+
+def recommend_actions(pr, checks_summary, failed_runs, new_review_items, retries_used, max_retries):
+    actions = []
+    if pr["closed"] or pr["merged"]:
+        if new_review_items:
+            actions.append("process_review_comment")
+        actions.append("stop_pr_closed")
+        return unique_actions(actions)
+
+    if is_pr_ready_to_merge(pr, checks_summary, new_review_items):
+        actions.append("stop_ready_to_merge")
+        return unique_actions(actions)
+
+    if new_review_items:
+        actions.append("process_review_comment")
+
+    has_failed_pr_checks = checks_summary["failed_count"] > 0
+    if has_failed_pr_checks:
+        if checks_summary["all_terminal"] and retries_used >= max_retries:
+            actions.append("stop_exhausted_retries")
+        else:
+            actions.append("diagnose_ci_failure")
+            if checks_summary["all_terminal"] and failed_runs and retries_used < max_retries:
+                actions.append("retry_failed_checks")
+
+    if not actions:
+        actions.append("idle")
+    return unique_actions(actions)
+
+
+def collect_snapshot(args):
+    pr = resolve_pr(args.pr, repo_override=args.repo)
+    state_path = Path(args.state_file) if args.state_file else default_state_file_for(pr)
+    state, _ = load_state(state_path)
+
+    if not state.get("started_at"):
+        state["started_at"] = int(time.time())
+
+    # `gh pr checks -R <repo>` requires an explicit PR/branch/url argument.
+    # After resolving `--pr auto`, reuse the concrete PR number.
+    checks = get_pr_checks(str(pr["number"]), repo=pr["repo"])
+    checks_summary = summarize_checks(checks)
+    workflow_runs = get_workflow_runs_for_sha(pr["repo"], pr["head_sha"])
+    failed_runs = failed_runs_from_workflow_runs(workflow_runs, pr["head_sha"])
+    authenticated_login = get_authenticated_login()
+    new_review_items = fetch_new_review_items(
+        pr,
+        state,
+        authenticated_login=authenticated_login,
+    )
+
+    retries_used = current_retry_count(state, pr["head_sha"])
+    actions = recommend_actions(
+        pr,
+        checks_summary,
+        failed_runs,
+        new_review_items,
+        retries_used,
+        args.max_flaky_retries,
+    )
+
+    state["pr"] = {"repo": pr["repo"], "number": pr["number"]}
+    state["last_seen_head_sha"] = pr["head_sha"]
+    state["last_snapshot_at"] = int(time.time())
+    save_state(state_path, state)
+
+    snapshot = {
+        "pr": pr,
+        "checks": checks_summary,
+        "failed_runs": failed_runs,
+        "new_review_items": new_review_items,
+        "actions": actions,
+        "retry_state": {
+            "current_sha_retries_used": retries_used,
+            "max_flaky_retries": args.max_flaky_retries,
+        },
+    }
+    return snapshot, state_path
+
+
+def retry_failed_now(args):
+    snapshot, state_path = collect_snapshot(args)
+    pr = snapshot["pr"]
+    checks_summary = snapshot["checks"]
+    failed_runs = snapshot["failed_runs"]
+    retries_used = snapshot["retry_state"]["current_sha_retries_used"]
+    max_retries = snapshot["retry_state"]["max_flaky_retries"]
+
+    result = {
+        "snapshot": snapshot,
+        "state_file": str(state_path),
+        "rerun_attempted": False,
+        "rerun_count": 0,
+        "rerun_run_ids": [],
+        "reason": None,
+    }
+
+    if pr["closed"] or pr["merged"]:
+        result["reason"] = "pr_closed"
+        return result
+    if checks_summary["failed_count"] <= 0:
+        result["reason"] = "no_failed_pr_checks"
+        return result
+    if not failed_runs:
+        result["reason"] = "no_failed_runs"
+        return result
+    if not checks_summary["all_terminal"]:
+        result["reason"] = "checks_still_pending"
+        return result
+    if retries_used >= max_retries:
+        result["reason"] = "retry_budget_exhausted"
+        return result
+
+    for run in failed_runs:
+        run_id = run.get("run_id")
+        if run_id in (None, ""):
+            continue
+        gh_text(["run", "rerun", str(run_id), "--failed"], repo=pr["repo"])
+        result["rerun_run_ids"].append(run_id)
+
+    if result["rerun_run_ids"]:
+        state, _ = load_state(state_path)
+        new_count = current_retry_count(state, pr["head_sha"]) + 1
+        set_retry_count(state, pr["head_sha"], new_count)
+        state["last_snapshot_at"] = int(time.time())
+        save_state(state_path, state)
+        result["rerun_attempted"] = True
+        result["rerun_count"] = len(result["rerun_run_ids"])
+        result["reason"] = "rerun_triggered"
+    else:
+        result["reason"] = "failed_runs_missing_ids"
+
+    return result
+
+
+def print_json(obj):
+    sys.stdout.write(json.dumps(obj, sort_keys=True) + "\n")
+    sys.stdout.flush()
+
+
+def print_event(event, payload):
+    print_json({"event": event, "payload": payload})
+
+
+def is_ci_green(snapshot):
+    checks = snapshot.get("checks") or {}
+    return (
+        bool(checks.get("all_terminal"))
+        and int(checks.get("failed_count") or 0) == 0
+        and int(checks.get("pending_count") or 0) == 0
+    )
+
+
+def snapshot_change_key(snapshot):
+    pr = snapshot.get("pr") or {}
+    checks = snapshot.get("checks") or {}
+    review_items = snapshot.get("new_review_items") or []
+    return (
+        str(pr.get("head_sha") or ""),
+        str(pr.get("state") or ""),
+        str(pr.get("mergeable") or ""),
+        str(pr.get("merge_state_status") or ""),
+        str(pr.get("review_decision") or ""),
+        int(checks.get("passed_count") or 0),
+        int(checks.get("failed_count") or 0),
+        int(checks.get("pending_count") or 0),
+        tuple(
+            (str(item.get("kind") or ""), str(item.get("id") or ""))
+            for item in review_items
+            if isinstance(item, dict)
+        ),
+        tuple(snapshot.get("actions") or []),
+    )
+
+
+def run_watch(args):
+    poll_seconds = args.poll_seconds
+    last_change_key = None
+    consecutive_errors = 0
+    max_consecutive_errors = 3
+
+    while True:
+        try:
+            snapshot, state_path = collect_snapshot(args)
+            consecutive_errors = 0
+        except (GhCommandError, RuntimeError, ValueError) as err:
+            consecutive_errors += 1
+            retry_seconds = min(args.poll_seconds * (2 ** (consecutive_errors - 1)), 5 * 60)
+            print_event(
+                "error",
+                {
+                    "message": str(err),
+                    "consecutive_errors": consecutive_errors,
+                    "max_consecutive_errors": max_consecutive_errors,
+                    "next_retry_seconds": retry_seconds,
+                },
+            )
+            if consecutive_errors >= max_consecutive_errors:
+                return 1
+            time.sleep(retry_seconds)
+            continue
+
+        print_event(
+            "snapshot",
+            {
+                "snapshot": snapshot,
+                "state_file": str(state_path),
+                "next_poll_seconds": poll_seconds,
+            },
+        )
+        actions = set(snapshot.get("actions") or [])
+        if (
+            "stop_pr_closed" in actions
+            or "stop_exhausted_retries" in actions
+            or "stop_ready_to_merge" in actions
+        ):
+            print_event("stop", {"actions": snapshot.get("actions"), "pr": snapshot.get("pr")})
+            return 0
+
+        current_change_key = snapshot_change_key(snapshot)
+        changed = current_change_key != last_change_key
+        green = is_ci_green(snapshot)
+
+        if not green:
+            poll_seconds = args.poll_seconds
+        elif changed or last_change_key is None:
+            poll_seconds = args.poll_seconds
+        else:
+            poll_seconds = min(poll_seconds * 2, GREEN_STATE_MAX_POLL_SECONDS)
+
+        last_change_key = current_change_key
+        time.sleep(poll_seconds)
+
+
+def main():
+    args = parse_args()
+    try:
+        if args.retry_failed_now:
+            print_json(retry_failed_now(args))
+            return 0
+        if args.watch:
+            return run_watch(args)
+        snapshot, state_path = collect_snapshot(args)
+        snapshot["state_file"] = str(state_path)
+        print_json(snapshot)
+        return 0
+    except (GhCommandError, RuntimeError, ValueError) as err:
+        sys.stderr.write(f"gh_pr_watch.py error: {err}\n")
+        return 1
+    except KeyboardInterrupt:
+        sys.stderr.write("gh_pr_watch.py interrupted\n")
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/frontend-slides/LICENSE.txt
+++ b/skills/frontend-slides/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Zara Zhang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/frontend-slides/README.md
+++ b/skills/frontend-slides/README.md
@@ -1,0 +1,178 @@
+# Frontend Slides
+
+An [Agent Skills](https://agentskills.io/) skill for creating stunning, animation-rich HTML presentations — from scratch or by converting PowerPoint files.
+
+This skill is published in the OpenHands extensions registry and can be used by OpenHands (CLI/GUI/Cloud) and other AgentSkills-compatible runtimes.
+
+## What This Does
+
+**Frontend Slides** helps non-designers create beautiful web presentations without knowing CSS or JavaScript. It uses a "show, don't tell" approach: instead of asking you to describe your aesthetic preferences in words, it generates visual previews and lets you pick what you like.
+
+### Key Features
+
+- **Zero Dependencies** — Single HTML files with inline CSS/JS. No npm, no build tools, no frameworks.
+- **Visual Style Discovery** — Can't articulate design preferences? No problem. Pick from generated visual previews.
+- **PPT Conversion** — Convert existing PowerPoint files to web, preserving all images and content.
+- **Anti-AI-Slop** — Curated distinctive styles that avoid generic AI aesthetics (bye-bye, purple gradients on white).
+- **Production Quality** — Accessible, responsive, well-commented code you can customize.
+
+## Installation
+
+### OpenHands (CLI / Local GUI)
+
+This skill uses the AgentSkills directory format. The **directory name must be `frontend-slides/`** and it must contain `SKILL.md` (plus the `references/` folder).
+
+- **Repository-level (recommended):** `.agents/skills/frontend-slides/`
+- **User-level:** `~/.agents/skills/frontend-slides/`
+
+```bash
+# Repository-level
+mkdir -p .agents/skills
+cp -R frontend-slides .agents/skills/frontend-slides
+
+# User-level
+mkdir -p ~/.agents/skills
+cp -R frontend-slides ~/.agents/skills/frontend-slides
+```
+
+### OpenHands Software Agent SDK
+
+- To auto-load skills from the public registry (https://github.com/OpenHands/extensions):
+
+```python
+from openhands.sdk import AgentContext
+
+agent_context = AgentContext(load_public_skills=True)
+```
+
+- To load this skill from a local directory (for example, `.agents/skills/`):
+
+```python
+from openhands.sdk import AgentContext
+from openhands.sdk.context.skills import load_skills_from_dir
+
+_, _, agent_skills = load_skills_from_dir(".agents/skills")
+agent_context = AgentContext(skills=list(agent_skills.values()))
+```
+
+References: https://docs.openhands.dev/overview/skills and https://docs.openhands.dev/sdk/guides/skill
+
+## Usage
+
+### Create a New Presentation
+
+```
+Create a pitch deck for my AI startup.
+
+Use the frontend-slides skill.
+```
+
+The skill will:
+1. Ask about your content (slides, messages, images)
+2. Ask about the feeling you want (impressed? excited? calm?)
+3. Generate 3 visual style previews for you to compare
+4. Create the full presentation in your chosen style
+5. Open it in your browser
+
+### Convert a PowerPoint
+
+```
+Convert my presentation.pptx to a web slideshow (HTML). Preserve text, images, and speaker notes.
+
+Use the frontend-slides skill.
+```
+
+The skill will:
+1. Extract all text, images, and notes from your PPT
+2. Show you the extracted content for confirmation
+3. Let you pick a visual style
+4. Generate an HTML presentation with all your original assets
+
+## Included Styles
+
+### Dark Themes
+- **Neon Cyber** — Futuristic, techy, particle effects
+- **Midnight Executive** — Premium, corporate, trustworthy
+- **Deep Space** — Cinematic, inspiring, vast
+- **Terminal Green** — Developer-focused, hacker aesthetic
+
+### Light Themes
+- **Paper & Ink** — Editorial, literary, refined
+- **Swiss Modern** — Clean, Bauhaus-inspired, geometric
+- **Soft Pastel** — Friendly, playful, creative
+- **Warm Editorial** — Magazine-style, photographic
+
+### Specialty
+- **Brutalist** — Raw, bold, attention-grabbing
+- **Gradient Wave** — Modern SaaS aesthetic
+
+## Output Example
+
+Each presentation is a single, self-contained HTML file:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!-- Fonts, CSS variables, all styles inline -->
+</head>
+<body>
+    <section class="slide title-slide">
+        <h1 class="reveal">Your Title</h1>
+    </section>
+
+    <section class="slide">
+        <h2 class="reveal">Slide Content</h2>
+    </section>
+
+    <!-- Navigation: Arrow keys, scroll, swipe, or click dots -->
+    <script>
+        // SlidePresentation controller, animations, interactions
+    </script>
+</body>
+</html>
+```
+
+Features included:
+- Keyboard navigation (arrows, space)
+- Touch/swipe support
+- Mouse wheel scrolling
+- Progress bar
+- Navigation dots
+- Scroll-triggered animations
+- Responsive design
+- Reduced motion support
+
+## Philosophy
+
+This skill was born from the belief that:
+
+1. **You don't need to be a designer to make beautiful things.** You just need to react to what you see.
+
+2. **Dependencies are debt.** A single HTML file will work in 10 years. A React project from 2019? Good luck.
+
+3. **Generic is forgettable.** Every presentation should feel custom-crafted, not template-generated.
+
+4. **Comments are kindness.** Code should explain itself to future-you (or anyone else who opens it).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `SKILL.md` | Skill definition (AgentSkills format) |
+| `references/STYLE_PRESETS.md` | Reference file with curated visual styles |
+
+## Requirements
+
+- OpenHands (CLI/GUI/Cloud) or the OpenHands Software Agent SDK (AgentSkills-compatible runtime)
+- For PPT conversion: Python with `python-pptx` library
+
+## Credits
+
+Originally created by [@zarazhangrui](https://github.com/zarazhangrui).
+
+Inspired by the "Vibe Coding" philosophy — building beautiful things without being a traditional software engineer.
+
+## License
+
+MIT — Use it, modify it, share it.

--- a/skills/frontend-slides/SKILL.md
+++ b/skills/frontend-slides/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: frontend-slides
+description: Create stunning, animation-rich HTML presentations from scratch or by converting PowerPoint files. Use when the user wants to build a presentation, convert a PPT/PPTX to web, or create slides for a talk/pitch. Helps non-designers discover their aesthetic through visual exploration rather than abstract choices.
+license: MIT (see LICENSE.txt)
+compatibility: For PPT/PPTX conversion requires Python and the python-pptx package.
+---
+
+# Frontend Slides Skill
+
+Create **zero-dependency**, animation-rich HTML presentations that run entirely in the browser.
+
+## Non-negotiables
+
+- **Single-file output:** generate a self-contained `.html` with inline CSS/JS (no npm, no build tools).
+- **Distinctive design:** avoid generic, templated “AI slop” aesthetics.
+- **Viewport fitting (CRITICAL):** every slide must fit exactly in the viewport; **no scrolling within slides**.
+  - Details + mandatory base CSS: see [references/VIEWPORT_FITTING.md](references/VIEWPORT_FITTING.md).
+
+## How to use (choose a mode)
+
+1. **New presentation** (from scratch)
+   - Use the structured workflow in [references/WORKFLOW.md](references/WORKFLOW.md).
+   - Use the style index in [references/STYLE_PRESETS.md](references/STYLE_PRESETS.md) and load the chosen preset from `references/presets/`.
+
+2. **PPT/PPTX conversion**
+   - Extract content + images with the workflow in [references/PPT_CONVERSION.md](references/PPT_CONVERSION.md).
+
+3. **Enhance an existing HTML presentation**
+   - Read the existing HTML/CSS/JS, preserve the content structure, then apply the same constraints:
+     - viewport fitting
+     - accessibility
+     - performance
+     - distinctive visuals
+
+## Design + animation references
+
+- Effect → feeling mapping: [references/STYLE_EFFECT_MAPPING.md](references/STYLE_EFFECT_MAPPING.md)
+- Animation patterns (CSS/JS snippets): [references/ANIMATION_PATTERNS.md](references/ANIMATION_PATTERNS.md)
+
+## Troubleshooting
+
+See [references/TROUBLESHOOTING.md](references/TROUBLESHOOTING.md).

--- a/skills/frontend-slides/references/ANIMATION_PATTERNS.md
+++ b/skills/frontend-slides/references/ANIMATION_PATTERNS.md
@@ -1,0 +1,98 @@
+## Animation Patterns Reference
+
+### Entrance Animations
+
+```css
+/* Fade + Slide Up (most common) */
+.reveal {
+    opacity: 0;
+    transform: translateY(30px);
+    transition: opacity 0.6s var(--ease-out-expo),
+                transform 0.6s var(--ease-out-expo);
+}
+
+.visible .reveal {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+/* Scale In */
+.reveal-scale {
+    opacity: 0;
+    transform: scale(0.9);
+    transition: opacity 0.6s, transform 0.6s var(--ease-out-expo);
+}
+
+/* Slide from Left */
+.reveal-left {
+    opacity: 0;
+    transform: translateX(-50px);
+    transition: opacity 0.6s, transform 0.6s var(--ease-out-expo);
+}
+
+/* Blur In */
+.reveal-blur {
+    opacity: 0;
+    filter: blur(10px);
+    transition: opacity 0.8s, filter 0.8s var(--ease-out-expo);
+}
+```
+
+### Background Effects
+
+```css
+/* Gradient Mesh */
+.gradient-bg {
+    background:
+        radial-gradient(ellipse at 20% 80%, rgba(120, 0, 255, 0.3) 0%, transparent 50%),
+        radial-gradient(ellipse at 80% 20%, rgba(0, 255, 200, 0.2) 0%, transparent 50%),
+        var(--bg-primary);
+}
+
+/* Noise Texture */
+.noise-bg {
+    background-image: url("data:image/svg+xml,..."); /* Inline SVG noise */
+}
+
+/* Grid Pattern */
+.grid-bg {
+    background-image:
+        linear-gradient(rgba(255,255,255,0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255,255,255,0.03) 1px, transparent 1px);
+    background-size: 50px 50px;
+}
+```
+
+### Interactive Effects
+
+```javascript
+/* 3D Tilt on Hover */
+class TiltEffect {
+    constructor(element) {
+        this.element = element;
+        this.element.style.transformStyle = 'preserve-3d';
+        this.element.style.perspective = '1000px';
+        this.bindEvents();
+    }
+
+    bindEvents() {
+        this.element.addEventListener('mousemove', (e) => {
+            const rect = this.element.getBoundingClientRect();
+            const x = (e.clientX - rect.left) / rect.width - 0.5;
+            const y = (e.clientY - rect.top) / rect.height - 0.5;
+
+            this.element.style.transform = `
+                rotateY(${x * 10}deg)
+                rotateX(${-y * 10}deg)
+            `;
+        });
+
+        this.element.addEventListener('mouseleave', () => {
+            this.element.style.transform = 'rotateY(0) rotateX(0)';
+        });
+    }
+}
+```
+
+---
+

--- a/skills/frontend-slides/references/PPT_CONVERSION.md
+++ b/skills/frontend-slides/references/PPT_CONVERSION.md
@@ -1,0 +1,121 @@
+## Phase 4: PPT Conversion
+
+When converting PowerPoint files:
+
+### Step 4.1: Extract Content
+
+Use Python with `python-pptx` to extract:
+
+```python
+from pptx import Presentation
+from pptx.enum.shapes import MSO_SHAPE_TYPE
+from pptx.util import Inches, Pt
+import json
+import os
+import base64
+
+def extract_pptx(file_path, output_dir):
+    """
+    Extract all content from a PowerPoint file.
+    Returns a JSON structure with slides, text, and images.
+    """
+    prs = Presentation(file_path)
+    slides_data = []
+
+    # Create assets directory
+    assets_dir = os.path.join(output_dir, 'assets')
+    os.makedirs(assets_dir, exist_ok=True)
+
+    for slide_num, slide in enumerate(prs.slides):
+        slide_data = {
+            'number': slide_num + 1,
+            'title': '',
+            'content': [],
+            'images': [],
+            'notes': ''
+        }
+
+        for shape in slide.shapes:
+            # Extract title
+            if shape.has_text_frame:
+                if shape == slide.shapes.title:
+                    slide_data['title'] = shape.text
+                else:
+                    slide_data['content'].append({
+                        'type': 'text',
+                        'content': shape.text
+                    })
+
+            # Extract images
+            if shape.shape_type == MSO_SHAPE_TYPE.PICTURE:
+                image = shape.image
+                image_bytes = image.blob
+                image_ext = image.ext
+                image_name = f"slide{slide_num + 1}_img{len(slide_data['images']) + 1}.{image_ext}"
+                image_path = os.path.join(assets_dir, image_name)
+
+                with open(image_path, 'wb') as f:
+                    f.write(image_bytes)
+
+                slide_data['images'].append({
+                    'path': f"assets/{image_name}",
+                    'width': shape.width,
+                    'height': shape.height
+                })
+
+        # Extract notes
+        if slide.has_notes_slide:
+            notes_frame = slide.notes_slide.notes_text_frame
+            slide_data['notes'] = notes_frame.text
+
+        slides_data.append(slide_data)
+
+    return slides_data
+```
+
+### Step 4.2: Confirm Content Structure
+
+Present the extracted content to the user:
+
+```
+I've extracted the following from your PowerPoint:
+
+**Slide 1: [Title]**
+- [Content summary]
+- Images: [count]
+
+**Slide 2: [Title]**
+- [Content summary]
+- Images: [count]
+
+...
+
+All images have been saved to the assets folder.
+
+Does this look correct? Should I proceed with style selection?
+```
+
+### Step 4.3: Style Selection
+
+Proceed to Phase 2 (Style Discovery) with the extracted content in mind.
+
+### Step 4.4: Generate HTML
+
+Convert the extracted content into the chosen style, preserving:
+- All text content
+- All images (referenced from assets folder)
+- Slide order
+- Any speaker notes (as HTML comments or separate file)
+
+---
+
+## Conversion Session Flow
+
+1. User: "Convert my slides.pptx to a web presentation"
+2. Skill extracts content and images from PPT
+3. Skill confirms extracted content with user
+4. Skill asks about desired feeling/style
+5. Skill generates style previews
+6. User picks a style
+7. Skill generates HTML presentation with preserved assets
+8. Final presentation delivered

--- a/skills/frontend-slides/references/STYLE_EFFECT_MAPPING.md
+++ b/skills/frontend-slides/references/STYLE_EFFECT_MAPPING.md
@@ -1,0 +1,52 @@
+## Style Reference: Effect → Feeling Mapping
+
+Use this guide to match animations to intended feelings:
+
+### Dramatic / Cinematic
+- Slow fade-ins (1-1.5s)
+- Large scale transitions (0.9 → 1)
+- Dark backgrounds with spotlight effects
+- Parallax scrolling
+- Full-bleed images
+
+### Techy / Futuristic
+- Neon glow effects (box-shadow with accent color)
+- Particle systems (canvas background)
+- Grid patterns
+- Monospace fonts for accents
+- Glitch or scramble text effects
+- Cyan, magenta, electric blue palette
+
+### Playful / Friendly
+- Bouncy easing (spring physics)
+- Rounded corners (large radius)
+- Pastel or bright colors
+- Floating/bobbing animations
+- Hand-drawn or illustrated elements
+
+### Professional / Corporate
+- Subtle, fast animations (200-300ms)
+- Clean sans-serif fonts
+- Navy, slate, or charcoal backgrounds
+- Precise spacing and alignment
+- Minimal decorative elements
+- Data visualization focus
+
+### Calm / Minimal
+- Very slow, subtle motion
+- High whitespace
+- Muted color palette
+- Serif typography
+- Generous padding
+- Content-focused, no distractions
+
+### Editorial / Magazine
+- Strong typography hierarchy
+- Pull quotes and callouts
+- Image-text interplay
+- Grid-breaking layouts
+- Serif headlines, sans-serif body
+- Black and white with one accent
+
+---
+

--- a/skills/frontend-slides/references/STYLE_PRESETS.md
+++ b/skills/frontend-slides/references/STYLE_PRESETS.md
@@ -1,0 +1,89 @@
+# Style Presets Reference
+
+Curated visual styles for Frontend Slides. Each preset is inspired by real design references—no generic “AI slop” aesthetics.
+
+**Rule:** abstract / geometric shapes only (no illustrations).
+
+---
+
+## CRITICAL: Viewport Fitting (Non-Negotiable)
+
+Every slide MUST fit exactly in the viewport. No scrolling within slides, ever.
+
+- Mandatory base CSS + breakpoints: see [VIEWPORT_FITTING.md](VIEWPORT_FITTING.md).
+
+### Content Density Limits Per Slide
+
+| Slide Type | Maximum Content |
+|------------|-----------------|
+| Title slide | 1 heading + 1 subtitle |
+| Content slide | 1 heading + 4-6 bullets (max 2 lines each) |
+| Feature grid | 1 heading + 6 cards (2x3 or 3x2) |
+| Code slide | 1 heading + 8-10 lines of code |
+| Quote slide | 1 quote (max 3 lines) + attribution |
+
+Too much content? Split into multiple slides. Never scroll.
+
+---
+
+## Presets (load only what you need)
+
+Each preset lives in its own file so agents can load just the chosen style:
+
+### Dark themes
+
+- **Bold Signal** — Confident, bold, modern, high-impact ([presets/bold-signal.md](presets/bold-signal.md))
+- **Electric Studio** — Bold, clean, professional, high contrast ([presets/electric-studio.md](presets/electric-studio.md))
+- **Creative Voltage** — Energetic retro-modern ([presets/creative-voltage.md](presets/creative-voltage.md))
+- **Dark Botanical** — Elegant, premium, artistic ([presets/dark-botanical.md](presets/dark-botanical.md))
+
+### Light themes
+
+- **Notebook Tabs** — Editorial, organized, tactile ([presets/notebook-tabs.md](presets/notebook-tabs.md))
+- **Pastel Geometry** — Friendly, modern, approachable ([presets/pastel-geometry.md](presets/pastel-geometry.md))
+- **Split Pastel** — Playful, creative ([presets/split-pastel.md](presets/split-pastel.md))
+- **Vintage Editorial** — Personality-driven editorial ([presets/vintage-editorial.md](presets/vintage-editorial.md))
+
+### Specialty themes
+
+- **Neon Cyber** — Futuristic, techy, confident ([presets/neon-cyber.md](presets/neon-cyber.md))
+- **Terminal Green** — Developer-focused, hacker aesthetic ([presets/terminal-green.md](presets/terminal-green.md))
+- **Swiss Modern** — Bauhaus-inspired precision ([presets/swiss-modern.md](presets/swiss-modern.md))
+- **Paper & Ink** — Literary editorial ([presets/paper-ink.md](presets/paper-ink.md))
+
+---
+
+## Font Pairing Quick Reference
+
+| Preset | Display Font | Body Font | Source |
+|--------|--------------|-----------|--------|
+| Bold Signal | Archivo Black | Space Grotesk | Google |
+| Electric Studio | Manrope | Manrope | Google |
+| Creative Voltage | Syne | Space Mono | Google |
+| Dark Botanical | Cormorant | IBM Plex Sans | Google |
+| Notebook Tabs | Bodoni Moda | DM Sans | Google |
+| Pastel Geometry | Plus Jakarta Sans | Plus Jakarta Sans | Google |
+| Split Pastel | Outfit | Outfit | Google |
+| Vintage Editorial | Fraunces | Work Sans | Google |
+| Neon Cyber | Clash Display | Satoshi | Fontshare |
+| Terminal Green | JetBrains Mono | JetBrains Mono | JetBrains |
+| Swiss Modern | Archivo | Nunito | Google |
+| Paper & Ink | Cormorant Garamond | Source Serif 4 | Google |
+
+---
+
+## DO NOT USE (Generic AI Patterns)
+
+- Fonts: Inter, Roboto, Arial, system fonts as display
+- Colors: `#6366f1` (generic indigo), purple gradients on white
+- Layouts: everything centered, generic hero sections, identical card grids
+- Decorations: realistic illustrations, gratuitous glassmorphism, purposeless shadows
+
+---
+
+## Troubleshooting
+
+If you hit viewport overflow / scaling issues, see:
+
+- [VIEWPORT_FITTING.md](VIEWPORT_FITTING.md)
+- [TROUBLESHOOTING.md](TROUBLESHOOTING.md)

--- a/skills/frontend-slides/references/TROUBLESHOOTING.md
+++ b/skills/frontend-slides/references/TROUBLESHOOTING.md
@@ -1,0 +1,28 @@
+## Troubleshooting
+
+### Common Issues
+
+**Fonts not loading:**
+- Check Fontshare/Google Fonts URL
+- Ensure font names match in CSS
+
+**Animations not triggering:**
+- Verify Intersection Observer is running
+- Check that `.visible` class is being added
+
+**Scroll snap not working:**
+- Ensure `scroll-snap-type` on html/body
+- Each slide needs `scroll-snap-align: start`
+
+**Mobile issues:**
+- Disable heavy effects at 768px breakpoint
+- Test touch events
+- Reduce particle count or disable canvas
+
+**Performance issues:**
+- Use `will-change` sparingly
+- Prefer `transform` and `opacity` animations
+- Throttle scroll/mousemove handlers
+
+---
+

--- a/skills/frontend-slides/references/VIEWPORT_FITTING.md
+++ b/skills/frontend-slides/references/VIEWPORT_FITTING.md
@@ -1,0 +1,228 @@
+## CRITICAL: Viewport Fitting Requirements
+
+**This section is mandatory for ALL presentations. Every slide must be fully visible without scrolling on any screen size.**
+
+### The Golden Rule
+
+```
+Each slide = exactly one viewport height (100vh/100dvh)
+Content overflows? → Split into multiple slides or reduce content
+Never scroll within a slide.
+```
+
+### Content Density Limits
+
+To guarantee viewport fitting, enforce these limits per slide:
+
+| Slide Type | Maximum Content |
+|------------|-----------------|
+| Title slide | 1 heading + 1 subtitle + optional tagline |
+| Content slide | 1 heading + 4-6 bullet points OR 1 heading + 2 paragraphs |
+| Feature grid | 1 heading + 6 cards maximum (2x3 or 3x2 grid) |
+| Code slide | 1 heading + 8-10 lines of code maximum |
+| Quote slide | 1 quote (max 3 lines) + attribution |
+| Image slide | 1 heading + 1 image (max 60vh height) |
+
+**If content exceeds these limits → Split into multiple slides**
+
+### Required CSS Architecture
+
+Every presentation MUST include this base CSS for viewport fitting:
+
+```css
+/* ===========================================
+   VIEWPORT FITTING: MANDATORY BASE STYLES
+   These styles MUST be included in every presentation.
+   They ensure slides fit exactly in the viewport.
+   =========================================== */
+
+/* 1. Lock html/body to viewport */
+html, body {
+    height: 100%;
+    overflow-x: hidden;
+}
+
+html {
+    scroll-snap-type: y mandatory;
+    scroll-behavior: smooth;
+}
+
+/* 2. Each slide = exact viewport height */
+.slide {
+    width: 100vw;
+    height: 100vh;
+    height: 100dvh; /* Dynamic viewport height for mobile browsers */
+    overflow: hidden; /* CRITICAL: Prevent ANY overflow */
+    scroll-snap-align: start;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+}
+
+/* 3. Content container with flex for centering */
+.slide-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    max-height: 100%;
+    overflow: hidden; /* Double-protection against overflow */
+    padding: var(--slide-padding);
+}
+
+/* 4. ALL typography uses clamp() for responsive scaling */
+:root {
+    /* Titles scale from mobile to desktop */
+    --title-size: clamp(1.5rem, 5vw, 4rem);
+    --h2-size: clamp(1.25rem, 3.5vw, 2.5rem);
+    --h3-size: clamp(1rem, 2.5vw, 1.75rem);
+
+    /* Body text */
+    --body-size: clamp(0.75rem, 1.5vw, 1.125rem);
+    --small-size: clamp(0.65rem, 1vw, 0.875rem);
+
+    /* Spacing scales with viewport */
+    --slide-padding: clamp(1rem, 4vw, 4rem);
+    --content-gap: clamp(0.5rem, 2vw, 2rem);
+    --element-gap: clamp(0.25rem, 1vw, 1rem);
+}
+
+/* 5. Cards/containers use viewport-relative max sizes */
+.card, .container, .content-box {
+    max-width: min(90vw, 1000px);
+    max-height: min(80vh, 700px);
+}
+
+/* 6. Lists auto-scale with viewport */
+.feature-list, .bullet-list {
+    gap: clamp(0.4rem, 1vh, 1rem);
+}
+
+.feature-list li, .bullet-list li {
+    font-size: var(--body-size);
+    line-height: 1.4;
+}
+
+/* 7. Grids adapt to available space */
+.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 250px), 1fr));
+    gap: clamp(0.5rem, 1.5vw, 1rem);
+}
+
+/* 8. Images constrained to viewport */
+img, .image-container {
+    max-width: 100%;
+    max-height: min(50vh, 400px);
+    object-fit: contain;
+}
+
+/* ===========================================
+   RESPONSIVE BREAKPOINTS
+   Aggressive scaling for smaller viewports
+   =========================================== */
+
+/* Short viewports (< 700px height) */
+@media (max-height: 700px) {
+    :root {
+        --slide-padding: clamp(0.75rem, 3vw, 2rem);
+        --content-gap: clamp(0.4rem, 1.5vw, 1rem);
+        --title-size: clamp(1.25rem, 4.5vw, 2.5rem);
+        --h2-size: clamp(1rem, 3vw, 1.75rem);
+    }
+}
+
+/* Very short viewports (< 600px height) */
+@media (max-height: 600px) {
+    :root {
+        --slide-padding: clamp(0.5rem, 2.5vw, 1.5rem);
+        --content-gap: clamp(0.3rem, 1vw, 0.75rem);
+        --title-size: clamp(1.1rem, 4vw, 2rem);
+        --body-size: clamp(0.7rem, 1.2vw, 0.95rem);
+    }
+
+    /* Hide non-essential elements */
+    .nav-dots, .keyboard-hint, .decorative {
+        display: none;
+    }
+}
+
+/* Extremely short (landscape phones, < 500px height) */
+@media (max-height: 500px) {
+    :root {
+        --slide-padding: clamp(0.4rem, 2vw, 1rem);
+        --title-size: clamp(1rem, 3.5vw, 1.5rem);
+        --h2-size: clamp(0.9rem, 2.5vw, 1.25rem);
+        --body-size: clamp(0.65rem, 1vw, 0.85rem);
+    }
+}
+
+/* Narrow viewports (< 600px width) */
+@media (max-width: 600px) {
+    :root {
+        --title-size: clamp(1.25rem, 7vw, 2.5rem);
+    }
+
+    /* Stack grids vertically */
+    .grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* ===========================================
+   REDUCED MOTION
+   Respect user preferences
+   =========================================== */
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        transition-duration: 0.2s !important;
+    }
+
+    html {
+        scroll-behavior: auto;
+    }
+}
+```
+
+### Overflow Prevention Checklist
+
+Before generating any presentation, mentally verify:
+
+1. ✅ Every `.slide` has `height: 100vh; height: 100dvh; overflow: hidden;`
+2. ✅ All font sizes use `clamp(min, preferred, max)`
+3. ✅ All spacing uses `clamp()` or viewport units
+4. ✅ Content containers have `max-height` constraints
+5. ✅ Images have `max-height: min(50vh, 400px)` or similar
+6. ✅ Grids use `auto-fit` with `minmax()` for responsive columns
+7. ✅ Breakpoints exist for heights: 700px, 600px, 500px
+8. ✅ No fixed pixel heights on content elements
+9. ✅ Content per slide respects density limits
+
+### When Content Doesn't Fit
+
+If you find yourself with too much content:
+
+**DO:**
+- Split into multiple slides
+- Reduce bullet points (max 5-6 per slide)
+- Shorten text (aim for 1-2 lines per bullet)
+- Use smaller code snippets
+- Create a "continued" slide
+
+**DON'T:**
+- Reduce font size below readable limits
+- Remove padding/spacing entirely
+- Allow any scrolling
+- Cram content to fit
+
+### Testing Viewport Fit
+
+After generating, recommend the user test at these sizes:
+- Desktop: 1920×1080, 1440×900, 1280×720
+- Tablet: 1024×768, 768×1024 (portrait)
+- Mobile: 375×667, 414×896
+- Landscape phone: 667×375, 896×414
+
+---
+

--- a/skills/frontend-slides/references/WORKFLOW.md
+++ b/skills/frontend-slides/references/WORKFLOW.md
@@ -1,0 +1,35 @@
+# Workflow (Index)
+
+This file is a lightweight index for the Frontend Slides workflow (split for progressive disclosure).
+
+## What to load
+
+- **New presentation (from scratch)** → [WORKFLOW_NEW_PRESENTATION.md](WORKFLOW_NEW_PRESENTATION.md) → [WORKFLOW_BUILD_PRESENTATION.md](WORKFLOW_BUILD_PRESENTATION.md) → [WORKFLOW_DELIVERY.md](WORKFLOW_DELIVERY.md)
+- **PPT/PPTX conversion** → [PPT_CONVERSION.md](PPT_CONVERSION.md) → [WORKFLOW_BUILD_PRESENTATION.md](WORKFLOW_BUILD_PRESENTATION.md) → [WORKFLOW_DELIVERY.md](WORKFLOW_DELIVERY.md)
+- **Enhance existing HTML** → [WORKFLOW_ENHANCEMENT.md](WORKFLOW_ENHANCEMENT.md)
+
+## Phase 0: Detect Mode
+
+First, determine what the user wants:
+
+**Mode A: New Presentation**
+- User wants to create slides from scratch
+- Load: [WORKFLOW_NEW_PRESENTATION.md](WORKFLOW_NEW_PRESENTATION.md)
+- Then: [WORKFLOW_BUILD_PRESENTATION.md](WORKFLOW_BUILD_PRESENTATION.md) → [WORKFLOW_DELIVERY.md](WORKFLOW_DELIVERY.md)
+
+**Mode B: PPT/PPTX Conversion**
+- User has a PowerPoint file (.ppt, .pptx) to convert
+- Load: [PPT_CONVERSION.md](PPT_CONVERSION.md)
+- Then: [WORKFLOW_BUILD_PRESENTATION.md](WORKFLOW_BUILD_PRESENTATION.md) → [WORKFLOW_DELIVERY.md](WORKFLOW_DELIVERY.md)
+
+**Mode C: Existing Presentation Enhancement**
+- User has an HTML presentation and wants to improve it
+- Load: [WORKFLOW_ENHANCEMENT.md](WORKFLOW_ENHANCEMENT.md)
+
+---
+
+
+## Next steps (common)
+
+- Build/generation checklist: [WORKFLOW_BUILD_PRESENTATION.md](WORKFLOW_BUILD_PRESENTATION.md)
+- Delivery checklist: [WORKFLOW_DELIVERY.md](WORKFLOW_DELIVERY.md)

--- a/skills/frontend-slides/references/WORKFLOW_BUILD_PRESENTATION.md
+++ b/skills/frontend-slides/references/WORKFLOW_BUILD_PRESENTATION.md
@@ -1,0 +1,288 @@
+# Workflow: Build Presentation
+
+Split from [WORKFLOW.md](WORKFLOW.md). Use after you have content + a chosen style.
+
+## Phase 3: Generate Presentation
+
+Now generate the full presentation based on:
+- Content from Phase 1
+- Style from Phase 2
+
+### File Structure
+
+For single presentations:
+```
+presentation.html    # Self-contained presentation
+assets/              # Images, if any
+```
+
+For projects with multiple presentations:
+```
+[presentation-name].html
+[presentation-name]-assets/
+```
+
+### HTML Architecture
+
+Follow this structure for all presentations:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Presentation Title</title>
+
+    <!-- Fonts (use Fontshare or Google Fonts) -->
+    <link rel="stylesheet" href="https://api.fontshare.com/v2/css?f[]=...">
+
+    <style>
+        /* ===========================================
+           CSS CUSTOM PROPERTIES (THEME)
+           Easy to modify: change these to change the whole look
+           =========================================== */
+        :root {
+            /* Colors */
+            --bg-primary: #0a0f1c;
+            --bg-secondary: #111827;
+            --text-primary: #ffffff;
+            --text-secondary: #9ca3af;
+            --accent: #00ffcc;
+            --accent-glow: rgba(0, 255, 204, 0.3);
+
+            /* Typography - MUST use clamp() for responsive scaling */
+            --font-display: 'Clash Display', sans-serif;
+            --font-body: 'Satoshi', sans-serif;
+            --title-size: clamp(2rem, 6vw, 5rem);
+            --subtitle-size: clamp(0.875rem, 2vw, 1.25rem);
+            --body-size: clamp(0.75rem, 1.2vw, 1rem);
+
+            /* Spacing - MUST use clamp() for responsive scaling */
+            --slide-padding: clamp(1.5rem, 4vw, 4rem);
+            --content-gap: clamp(1rem, 2vw, 2rem);
+
+            /* Animation */
+            --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+            --duration-normal: 0.6s;
+        }
+
+        /* ===========================================
+           BASE STYLES
+           =========================================== */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        html {
+            scroll-behavior: smooth;
+            scroll-snap-type: y mandatory;
+            height: 100%;
+        }
+
+        body {
+            font-family: var(--font-body);
+            background: var(--bg-primary);
+            color: var(--text-primary);
+            overflow-x: hidden;
+            height: 100%;
+        }
+
+        /* ===========================================
+           SLIDE CONTAINER
+           CRITICAL: Each slide MUST fit exactly in viewport
+           - Use height: 100vh (NOT min-height)
+           - Use overflow: hidden to prevent scroll
+           - Content must scale with clamp() values
+           =========================================== */
+        .slide {
+            width: 100vw;
+            height: 100vh; /* EXACT viewport height - no scrolling */
+            height: 100dvh; /* Dynamic viewport height for mobile */
+            padding: var(--slide-padding);
+            scroll-snap-align: start;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            position: relative;
+            overflow: hidden; /* Prevent any content overflow */
+        }
+
+        /* Content wrapper that prevents overflow */
+        .slide-content {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            max-height: 100%;
+            overflow: hidden;
+        }
+
+        /* ===========================================
+           RESPONSIVE BREAKPOINTS
+           Adjust content for different screen sizes
+           =========================================== */
+        @media (max-height: 600px) {
+            :root {
+                --slide-padding: clamp(1rem, 3vw, 2rem);
+                --content-gap: clamp(0.5rem, 1.5vw, 1rem);
+            }
+        }
+
+        @media (max-width: 768px) {
+            :root {
+                --title-size: clamp(1.5rem, 8vw, 3rem);
+            }
+        }
+
+        @media (max-height: 500px) and (orientation: landscape) {
+            /* Extra compact for landscape phones */
+            :root {
+                --title-size: clamp(1.25rem, 5vw, 2rem);
+                --slide-padding: clamp(0.75rem, 2vw, 1.5rem);
+            }
+        }
+
+        /* ===========================================
+           ANIMATIONS
+           Trigger via .visible class (added by JS on scroll)
+           =========================================== */
+        .reveal {
+            opacity: 0;
+            transform: translateY(30px);
+            transition: opacity var(--duration-normal) var(--ease-out-expo),
+                        transform var(--duration-normal) var(--ease-out-expo);
+        }
+
+        .slide.visible .reveal {
+            opacity: 1;
+            transform: translateY(0);
+        }
+
+        /* Stagger children */
+        .reveal:nth-child(1) { transition-delay: 0.1s; }
+        .reveal:nth-child(2) { transition-delay: 0.2s; }
+        .reveal:nth-child(3) { transition-delay: 0.3s; }
+        .reveal:nth-child(4) { transition-delay: 0.4s; }
+
+        /* ... more styles ... */
+    </style>
+</head>
+<body>
+    <!-- Progress bar (optional) -->
+    <div class="progress-bar"></div>
+
+    <!-- Navigation dots (optional) -->
+    <nav class="nav-dots">
+        <!-- Generated by JS -->
+    </nav>
+
+    <!-- Slides -->
+    <section class="slide title-slide">
+        <h1 class="reveal">Presentation Title</h1>
+        <p class="reveal">Subtitle or author</p>
+    </section>
+
+    <section class="slide">
+        <h2 class="reveal">Slide Title</h2>
+        <p class="reveal">Content...</p>
+    </section>
+
+    <!-- More slides... -->
+
+    <script>
+        /* ===========================================
+           SLIDE PRESENTATION CONTROLLER
+           Handles navigation, animations, and interactions
+           =========================================== */
+
+        class SlidePresentation {
+            constructor() {
+                // ... initialization
+            }
+
+            // ... methods
+        }
+
+        // Initialize
+        new SlidePresentation();
+    </script>
+</body>
+</html>
+```
+
+### Required JavaScript Features
+
+Every presentation should include:
+
+1. **SlidePresentation Class** — Main controller
+   - Keyboard navigation (arrows, space)
+   - Touch/swipe support
+   - Mouse wheel navigation
+   - Progress bar updates
+   - Navigation dots
+
+2. **Intersection Observer** — For scroll-triggered animations
+   - Add `.visible` class when slides enter viewport
+   - Trigger CSS animations efficiently
+
+3. **Optional Enhancements** (based on style):
+   - Custom cursor with trail
+   - Particle system background (canvas)
+   - Parallax effects
+   - 3D tilt on hover
+   - Magnetic buttons
+   - Counter animations
+
+### Code Quality Requirements
+
+**Comments:**
+Every section should have clear comments explaining:
+- What it does
+- Why it exists
+- How to modify it
+
+```javascript
+/* ===========================================
+   CUSTOM CURSOR
+   Creates a stylized cursor that follows mouse with a trail effect.
+   - Uses lerp (linear interpolation) for smooth movement
+   - Grows larger when hovering over interactive elements
+   =========================================== */
+class CustomCursor {
+    constructor() {
+        // ...
+    }
+}
+```
+
+**Accessibility:**
+- Semantic HTML (`<section>`, `<nav>`, `<main>`)
+- Keyboard navigation works
+- ARIA labels where needed
+- Reduced motion support
+
+```css
+@media (prefers-reduced-motion: reduce) {
+    .reveal {
+        transition: opacity 0.3s ease;
+        transform: none;
+    }
+}
+```
+
+**Responsive & Viewport Fitting (CRITICAL):**
+
+See [VIEWPORT_FITTING.md](VIEWPORT_FITTING.md) for the full mandatory base CSS and guidelines.
+
+Quick reference:
+- Every `.slide` must have `height: 100vh; height: 100dvh; overflow: hidden;`
+- All typography and spacing must use `clamp()`
+- Respect content density limits (max 4-6 bullets, max 6 cards, etc.)
+- Include breakpoints for heights: 700px, 600px, 500px
+- When content doesn't fit → split into multiple slides, never scroll
+
+---
+

--- a/skills/frontend-slides/references/WORKFLOW_DELIVERY.md
+++ b/skills/frontend-slides/references/WORKFLOW_DELIVERY.md
@@ -1,0 +1,62 @@
+# Workflow: Delivery
+
+Split from [WORKFLOW.md](WORKFLOW.md).
+
+## Phase 5: Delivery
+
+### Final Output
+
+When the presentation is complete:
+
+1. **Clean up temporary files**
+   - Delete `.frontend-slides/slide-previews/` if it exists
+
+2. **Open the presentation**
+   - Use `open [filename].html` to launch in browser
+
+3. **Provide summary**
+```
+Your presentation is ready!
+
+📁 File: [filename].html
+🎨 Style: [Style Name]
+📊 Slides: [count]
+
+**Navigation:**
+- Arrow keys (← →) or Space to navigate
+- Scroll/swipe also works
+- Click the dots on the right to jump to a slide
+
+**To customize:**
+- Colors: Look for `:root` CSS variables at the top
+- Fonts: Change the Fontshare/Google Fonts link
+- Animations: Modify `.reveal` class timings
+
+Would you like me to make any adjustments?
+```
+
+---
+
+## Related Skills
+
+- **learn** — Generate FORZARA.md documentation for the presentation
+- **frontend-design** — For more complex interactive pages beyond slides
+- **design-and-refine:design-lab** — For iterating on component designs
+
+---
+
+## Example Session Flow
+
+1. User: "I want to create a pitch deck for my AI startup"
+2. Skill asks about purpose, length, content
+3. User shares their bullet points and key messages
+4. Skill asks about desired feeling (Impressed + Excited)
+5. Skill generates 3 style previews
+6. User picks Style B (Neon Cyber), asks for darker background
+7. Skill generates full presentation with all slides
+8. Skill opens the presentation in browser
+9. User requests tweaks to specific slides
+10. Final presentation delivered
+
+---
+

--- a/skills/frontend-slides/references/WORKFLOW_ENHANCEMENT.md
+++ b/skills/frontend-slides/references/WORKFLOW_ENHANCEMENT.md
@@ -1,0 +1,18 @@
+# Workflow: Enhance an Existing HTML Presentation
+
+Use when the user provides an existing HTML presentation and asks for improvements.
+
+## Steps
+
+1. Read the existing HTML/CSS/JS and summarize the structure (slides, navigation, animations).
+2. Apply the **non-negotiables** from the skill:
+   - Viewport fitting (no scrolling inside slides): see [VIEWPORT_FITTING.md](VIEWPORT_FITTING.md).
+   - Single-file output (keep CSS/JS inline unless the user asks otherwise).
+   - Distinctive design (avoid generic templates): see [STYLE_PRESETS.md](STYLE_PRESETS.md).
+3. Make changes incrementally and re-check for overflow after each slide change.
+4. Keep accessibility and reduced-motion support intact (or improve it if missing).
+
+## After enhancement
+
+- If you need the canonical architecture checklist, load [WORKFLOW_BUILD_PRESENTATION.md](WORKFLOW_BUILD_PRESENTATION.md).
+- For the handoff checklist, load [WORKFLOW_DELIVERY.md](WORKFLOW_DELIVERY.md).

--- a/skills/frontend-slides/references/WORKFLOW_NEW_PRESENTATION.md
+++ b/skills/frontend-slides/references/WORKFLOW_NEW_PRESENTATION.md
@@ -1,0 +1,196 @@
+# Workflow: New Presentation
+
+Split from [WORKFLOW.md](WORKFLOW.md) for progressive disclosure.
+
+## Phase 1: Content Discovery (New Presentations)
+
+Before designing, understand the content. Ask the user:
+
+### Step 1.1: Presentation Context
+
+**Question 1: Purpose**
+- Header: "Purpose"
+- Question: "What is this presentation for?"
+- Options:
+  - "Pitch deck" — Selling an idea, product, or company to investors/clients
+  - "Teaching/Tutorial" — Explaining concepts, how-to guides, educational content
+  - "Conference talk" — Speaking at an event, tech talk, keynote
+  - "Internal presentation" — Team updates, strategy meetings, company updates
+
+**Question 2: Slide Count**
+- Header: "Length"
+- Question: "Approximately how many slides?"
+- Options:
+  - "Short (5-10)" — Quick pitch, lightning talk
+  - "Medium (10-20)" — Standard presentation
+  - "Long (20+)" — Deep dive, comprehensive talk
+
+**Question 3: Content**
+- Header: "Content"
+- Question: "Do you have the content ready, or do you need help structuring it?"
+- Options:
+  - "I have all content ready" — Just need to design the presentation
+  - "I have rough notes" — Need help organizing into slides
+  - "I have a topic only" — Need help creating the full outline
+
+If user has content, ask them to share it (text, bullet points, images, etc.).
+
+---
+
+## Phase 2: Style Discovery (Visual Exploration)
+
+**CRITICAL: This is the "show, don't tell" phase.**
+
+Most people can't articulate design preferences in words. Instead of asking "do you want minimalist or bold?", we generate mini-previews and let them react.
+
+### How Users Choose Presets
+
+Users can select a style in **two ways**:
+
+**Option A: Guided Discovery (Default)**
+- User answers mood questions
+- Skill generates 3 preview files based on their answers
+- User views previews in browser and picks their favorite
+- This is best for users who don't have a specific style in mind
+
+**Option B: Direct Selection**
+- If user already knows what they want, they can request a preset by name
+- Example: "Use the Bold Signal style" or "I want something like Dark Botanical"
+- Skip to Phase 3 immediately
+
+**Available Presets:**
+| Preset | Vibe | Best For |
+|--------|------|----------|
+| Bold Signal | Confident, high-impact | Pitch decks, keynotes |
+| Electric Studio | Clean, professional | Agency presentations |
+| Creative Voltage | Energetic, retro-modern | Creative pitches |
+| Dark Botanical | Elegant, sophisticated | Premium brands |
+| Notebook Tabs | Editorial, organized | Reports, reviews |
+| Pastel Geometry | Friendly, approachable | Product overviews |
+| Split Pastel | Playful, modern | Creative agencies |
+| Vintage Editorial | Witty, personality-driven | Personal brands |
+| Neon Cyber | Futuristic, techy | Tech startups |
+| Terminal Green | Developer-focused | Dev tools, APIs |
+| Swiss Modern | Minimal, precise | Corporate, data |
+| Paper & Ink | Literary, thoughtful | Storytelling |
+
+### Step 2.0: Style Path Selection
+
+First, ask how the user wants to choose their style:
+
+**Question: Style Selection Method**
+- Header: "Style"
+- Question: "How would you like to choose your presentation style?"
+- Options:
+  - "Show me options" — Generate 3 previews based on my needs (recommended for most users)
+  - "I know what I want" — Let me pick from the preset list directly
+
+**If "Show me options"** → Continue to Step 2.1 (Mood Selection)
+
+**If "I know what I want"** → Show preset picker:
+
+**Question: Pick a Preset**
+- Header: "Preset"
+- Question: "Which style would you like to use?"
+- Options:
+  - "Bold Signal" — Vibrant card on dark, confident and high-impact
+  - "Dark Botanical" — Elegant dark with soft abstract shapes
+  - "Notebook Tabs" — Editorial paper look with colorful section tabs
+  - "Pastel Geometry" — Friendly pastels with decorative pills
+
+(If user picks one, skip to Phase 3. If they want to see more options, show additional presets or proceed to guided discovery.)
+
+### Step 2.1: Mood Selection (Guided Discovery)
+
+**Question 1: Feeling**
+- Header: "Vibe"
+- Question: "What feeling should the audience have when viewing your slides?"
+- Options:
+  - "Impressed/Confident" — Professional, trustworthy, this team knows what they're doing
+  - "Excited/Energized" — Innovative, bold, this is the future
+  - "Calm/Focused" — Clear, thoughtful, easy to follow
+  - "Inspired/Moved" — Emotional, storytelling, memorable
+- multiSelect: true (can choose up to 2)
+
+### Step 2.2: Generate Style Previews
+
+Based on their mood selection, generate **3 distinct style previews** as mini HTML files in a temporary directory. Each preview should be a single title slide showing:
+
+- Typography (font choices, heading/body hierarchy)
+- Color palette (background, accent, text colors)
+- Animation style (how elements enter)
+- Overall aesthetic feel
+
+**Preview Styles to Consider (pick 3 based on mood):**
+
+| Mood | Style Options |
+|------|---------------|
+| Impressed/Confident | "Bold Signal", "Electric Studio", "Dark Botanical" |
+| Excited/Energized | "Creative Voltage", "Neon Cyber", "Split Pastel" |
+| Calm/Focused | "Notebook Tabs", "Paper & Ink", "Swiss Modern" |
+| Inspired/Moved | "Dark Botanical", "Vintage Editorial", "Pastel Geometry" |
+
+**IMPORTANT: Never use these generic patterns:**
+- Purple gradients on white backgrounds
+- Inter, Roboto, or system fonts
+- Standard blue primary colors
+- Predictable hero layouts
+
+**Instead, use distinctive choices:**
+- Unique font pairings (Clash Display, Satoshi, Cormorant Garamond, DM Sans, etc.)
+- Cohesive color themes with personality
+- Atmospheric backgrounds (gradients, subtle patterns, depth)
+- Signature animation moments
+
+### Step 2.3: Present Previews
+
+Create the previews in: `.frontend-slides/slide-previews/`
+
+```
+.frontend-slides/slide-previews/
+├── style-a.html   # First style option
+├── style-b.html   # Second style option
+├── style-c.html   # Third style option
+└── assets/        # Any shared assets
+```
+
+Each preview file should be:
+- Self-contained (inline CSS/JS)
+- A single "title slide" showing the aesthetic
+- Animated to demonstrate motion style
+- ~50-100 lines, not a full presentation
+
+Present to user:
+```
+I've created 3 style previews for you to compare:
+
+**Style A: [Name]** — [1 sentence description]
+**Style B: [Name]** — [1 sentence description]
+**Style C: [Name]** — [1 sentence description]
+
+Open each file to see them in action:
+- .frontend-slides/slide-previews/style-a.html
+- .frontend-slides/slide-previews/style-b.html
+- .frontend-slides/slide-previews/style-c.html
+
+Take a look and tell me:
+1. Which style resonates most?
+2. What do you like about it?
+3. Anything you'd change?
+```
+
+Then ask the user:
+
+**Question: Pick Your Style**
+- Header: "Style"
+- Question: "Which style preview do you prefer?"
+- Options:
+  - "Style A: [Name]" — [Brief description]
+  - "Style B: [Name]" — [Brief description]
+  - "Style C: [Name]" — [Brief description]
+  - "Mix elements" — Combine aspects from different styles
+
+If "Mix elements", ask for specifics.
+
+---
+

--- a/skills/frontend-slides/references/presets/bold-signal.md
+++ b/skills/frontend-slides/references/presets/bold-signal.md
@@ -1,0 +1,28 @@
+# Bold Signal
+
+**Vibe:** Confident, bold, modern, high-impact
+
+**Layout:** Colored card on dark gradient. Number top-left, navigation top-right, title bottom-left.
+
+**Typography:**
+- Display: `Archivo Black` (900)
+- Body: `Space Grotesk` (400/500)
+
+**Colors:**
+```css
+:root {
+    --bg-primary: #1a1a1a;
+    --bg-gradient: linear-gradient(135deg, #1a1a1a 0%, #2d2d2d 50%, #1a1a1a 100%);
+    --card-bg: #FF5722;
+    --text-primary: #ffffff;
+    --text-on-card: #1a1a1a;
+}
+```
+
+**Signature Elements:**
+- Bold colored card as focal point (orange, coral, or vibrant accent)
+- Large section numbers (01, 02, etc.)
+- Navigation breadcrumbs with active/inactive opacity states
+- Grid-based layout for precise alignment
+
+---

--- a/skills/frontend-slides/references/presets/creative-voltage.md
+++ b/skills/frontend-slides/references/presets/creative-voltage.md
@@ -1,0 +1,27 @@
+# Creative Voltage
+
+**Vibe:** Bold, creative, energetic, retro-modern
+
+**Layout:** Split panels—electric blue left, dark right. Script accents.
+
+**Typography:**
+- Display: `Syne` (700/800)
+- Mono: `Space Mono` (400/700)
+
+**Colors:**
+```css
+:root {
+    --bg-primary: #0066ff;
+    --bg-dark: #1a1a2e;
+    --accent-neon: #d4ff00;
+    --text-light: #ffffff;
+}
+```
+
+**Signature Elements:**
+- Electric blue + neon yellow contrast
+- Halftone texture patterns
+- Neon badges/callouts
+- Script typography for creative flair
+
+---

--- a/skills/frontend-slides/references/presets/dark-botanical.md
+++ b/skills/frontend-slides/references/presets/dark-botanical.md
@@ -1,0 +1,30 @@
+# Dark Botanical
+
+**Vibe:** Elegant, sophisticated, artistic, premium
+
+**Layout:** Centered content on dark. Abstract soft shapes in corner.
+
+**Typography:**
+- Display: `Cormorant` (400/600) — elegant serif
+- Body: `IBM Plex Sans` (300/400)
+
+**Colors:**
+```css
+:root {
+    --bg-primary: #0f0f0f;
+    --text-primary: #e8e4df;
+    --text-secondary: #9a9590;
+    --accent-warm: #d4a574;
+    --accent-pink: #e8b4b8;
+    --accent-gold: #c9b896;
+}
+```
+
+**Signature Elements:**
+- Abstract soft gradient circles (blurred, overlapping)
+- Warm color accents (pink, gold, terracotta)
+- Thin vertical accent lines
+- Italic signature typography
+- **No illustrations—only abstract CSS shapes**
+
+---

--- a/skills/frontend-slides/references/presets/electric-studio.md
+++ b/skills/frontend-slides/references/presets/electric-studio.md
@@ -1,0 +1,28 @@
+# Electric Studio
+
+**Vibe:** Bold, clean, professional, high contrast
+
+**Layout:** Split panel—white top, blue bottom. Brand marks in corners.
+
+**Typography:**
+- Display: `Manrope` (800)
+- Body: `Manrope` (400/500)
+
+**Colors:**
+```css
+:root {
+    --bg-dark: #0a0a0a;
+    --bg-white: #ffffff;
+    --accent-blue: #4361ee;
+    --text-dark: #0a0a0a;
+    --text-light: #ffffff;
+}
+```
+
+**Signature Elements:**
+- Two-panel vertical split
+- Accent bar on panel edge
+- Quote typography as hero element
+- Minimal, confident spacing
+
+---

--- a/skills/frontend-slides/references/presets/neon-cyber.md
+++ b/skills/frontend-slides/references/presets/neon-cyber.md
@@ -1,0 +1,11 @@
+# Neon Cyber
+
+**Vibe:** Futuristic, techy, confident
+
+**Typography:** `Clash Display` + `Satoshi` (Fontshare)
+
+**Colors:** Deep navy (#0a0f1c), cyan accent (#00ffcc), magenta (#ff00aa)
+
+**Signature:** Particle backgrounds, neon glow, grid patterns
+
+---

--- a/skills/frontend-slides/references/presets/notebook-tabs.md
+++ b/skills/frontend-slides/references/presets/notebook-tabs.md
@@ -1,0 +1,31 @@
+# Notebook Tabs
+
+**Vibe:** Editorial, organized, elegant, tactile
+
+**Layout:** Cream paper card on dark background. Colorful tabs on right edge.
+
+**Typography:**
+- Display: `Bodoni Moda` (400/700) — classic editorial
+- Body: `DM Sans` (400/500)
+
+**Colors:**
+```css
+:root {
+    --bg-outer: #2d2d2d;
+    --bg-page: #f8f6f1;
+    --text-primary: #1a1a1a;
+    --tab-1: #98d4bb; /* Mint */
+    --tab-2: #c7b8ea; /* Lavender */
+    --tab-3: #f4b8c5; /* Pink */
+    --tab-4: #a8d8ea; /* Sky */
+    --tab-5: #ffe6a7; /* Cream */
+}
+```
+
+**Signature Elements:**
+- Paper container with subtle shadow
+- Colorful section tabs on right edge (vertical text)
+- Binder hole decorations on left
+- Tab text must scale with viewport: `font-size: clamp(0.5rem, 1vh, 0.7rem)`
+
+---

--- a/skills/frontend-slides/references/presets/paper-ink.md
+++ b/skills/frontend-slides/references/presets/paper-ink.md
@@ -1,0 +1,11 @@
+# Paper & Ink
+
+**Vibe:** Editorial, literary, thoughtful
+
+**Typography:** `Cormorant Garamond` + `Source Serif 4`
+
+**Colors:** Warm cream (#faf9f7), charcoal (#1a1a1a), crimson accent (#c41e3a)
+
+**Signature:** Drop caps, pull quotes, elegant horizontal rules
+
+---

--- a/skills/frontend-slides/references/presets/pastel-geometry.md
+++ b/skills/frontend-slides/references/presets/pastel-geometry.md
@@ -1,0 +1,30 @@
+# Pastel Geometry
+
+**Vibe:** Friendly, organized, modern, approachable
+
+**Layout:** White card on pastel background. Vertical pills on right edge.
+
+**Typography:**
+- Display: `Plus Jakarta Sans` (700/800)
+- Body: `Plus Jakarta Sans` (400/500)
+
+**Colors:**
+```css
+:root {
+    --bg-primary: #c8d9e6;
+    --card-bg: #faf9f7;
+    --pill-pink: #f0b4d4;
+    --pill-mint: #a8d4c4;
+    --pill-sage: #5a7c6a;
+    --pill-lavender: #9b8dc4;
+    --pill-violet: #7c6aad;
+}
+```
+
+**Signature Elements:**
+- Rounded card with soft shadow
+- **Vertical pills on right edge** with varying heights (like tabs)
+- Consistent pill width, heights: short → medium → tall → medium → short
+- Download/action icon in corner
+
+---

--- a/skills/frontend-slides/references/presets/split-pastel.md
+++ b/skills/frontend-slides/references/presets/split-pastel.md
@@ -1,0 +1,29 @@
+# Split Pastel
+
+**Vibe:** Playful, modern, friendly, creative
+
+**Layout:** Two-color vertical split (peach left, lavender right).
+
+**Typography:**
+- Display: `Outfit` (700/800)
+- Body: `Outfit` (400/500)
+
+**Colors:**
+```css
+:root {
+    --bg-peach: #f5e6dc;
+    --bg-lavender: #e4dff0;
+    --text-dark: #1a1a1a;
+    --badge-mint: #c8f0d8;
+    --badge-yellow: #f0f0c8;
+    --badge-pink: #f0d4e0;
+}
+```
+
+**Signature Elements:**
+- Split background colors
+- Playful badge pills with icons
+- Grid pattern overlay on right panel
+- Rounded CTA buttons
+
+---

--- a/skills/frontend-slides/references/presets/swiss-modern.md
+++ b/skills/frontend-slides/references/presets/swiss-modern.md
@@ -1,0 +1,11 @@
+# Swiss Modern
+
+**Vibe:** Clean, precise, Bauhaus-inspired
+
+**Typography:** `Archivo` (800) + `Nunito` (400)
+
+**Colors:** Pure white, pure black, red accent (#ff3300)
+
+**Signature:** Visible grid, asymmetric layouts, geometric shapes
+
+---

--- a/skills/frontend-slides/references/presets/terminal-green.md
+++ b/skills/frontend-slides/references/presets/terminal-green.md
@@ -1,0 +1,11 @@
+# Terminal Green
+
+**Vibe:** Developer-focused, hacker aesthetic
+
+**Typography:** `JetBrains Mono` (monospace only)
+
+**Colors:** GitHub dark (#0d1117), terminal green (#39d353)
+
+**Signature:** Scan lines, blinking cursor, code syntax styling
+
+---

--- a/skills/frontend-slides/references/presets/vintage-editorial.md
+++ b/skills/frontend-slides/references/presets/vintage-editorial.md
@@ -1,0 +1,29 @@
+# Vintage Editorial
+
+**Vibe:** Witty, confident, editorial, personality-driven
+
+**Layout:** Centered content on cream. Abstract geometric shapes as accent.
+
+**Typography:**
+- Display: `Fraunces` (700/900) — distinctive serif
+- Body: `Work Sans` (400/500)
+
+**Colors:**
+```css
+:root {
+    --bg-cream: #f5f3ee;
+    --text-primary: #1a1a1a;
+    --text-secondary: #555;
+    --accent-warm: #e8d4c0;
+}
+```
+
+**Signature Elements:**
+- Abstract geometric shapes (circle outline + line + dot)
+- Bold bordered CTA boxes
+- Witty, conversational copy style
+- **No illustrations—only geometric CSS shapes**
+
+---
+
+## Specialty Themes

--- a/skills/openhands-api-v1/README.md
+++ b/skills/openhands-api-v1/README.md
@@ -1,0 +1,28 @@
+# openhands-api-v1
+
+Minimal skill + reference client for the **OpenHands Cloud API V1**.
+
+- Skill instructions and endpoint overview: [`SKILL.md`](./SKILL.md)
+- Minimal Python client: [`scripts/openhands_api_v1.py`](./scripts/openhands_api_v1.py)
+- Minimal TypeScript client: [`scripts/openhands_api_v1.ts`](./scripts/openhands_api_v1.ts)
+- References: [`references/README.md`](./references/README.md)
+
+## Quick start
+
+```bash
+export OPENHANDS_API_KEY="..."
+python skills/openhands-api-v1/scripts/openhands_api_v1.py search-conversations --limit 5
+```
+
+## Start-task vs app conversation id
+
+In many deployments, `POST /api/v1/app-conversations` returns a **start-task** object.
+
+- `id` is the **start_task_id**
+- `app_conversation_id` is what you should use for `/download` and `/conversation/.../events/...`
+
+If `app_conversation_id` is missing from the initial response, fetch it via:
+
+- `GET /api/v1/app-conversations/start-tasks?ids=<start_task_id>`
+
+(If you accidentally use a start-task id with `/download`, you’ll get `404 Not Found`.)

--- a/skills/openhands-api-v1/SKILL.md
+++ b/skills/openhands-api-v1/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: openhands-api-v1
+description: Minimal reference skill for the OpenHands Cloud REST API (V1) (app server /api/v1 + sandbox agent-server). Use when you need to automate common OpenHands Cloud actions; don't use for general sandbox/dev tasks unrelated to the OpenHands API.
+triggers:
+- openhands-api-v1
+- oh-cloud-api
+- oh-api
+- agent-server
+- agent-server-api
+---
+
+This skill documents the **OpenHands Cloud API V1** and provides a small, easy-to-copy Python client.
+
+It is intentionally minimal and focused on common operations:
+
+- Defaults to OpenHands Cloud (`https://app.all-hands.dev`).
+- Targets the **V1 app server REST API** under `/api/v1/...`.
+- Includes a few **agent server** endpoints (inside a sandbox) that use `X-Session-API-Key`.
+
+## Auth
+
+### App server (Cloud)
+
+Use Bearer auth:
+
+- Header: `Authorization: Bearer <OPENHANDS_API_KEY>`
+- Env var: `OPENHANDS_API_KEY`
+
+### Agent server (inside a sandbox)
+
+Use session auth:
+
+- Header: `X-Session-API-Key: <session_api_key>`
+
+How to obtain `agent_server_url` and `session_api_key`:
+
+1. Start or fetch an app conversation via the app server (Bearer auth), e.g.:
+   - `POST /api/v1/app-conversations`
+   - or `GET /api/v1/app-conversations?ids=<conversation_id>`
+2. In the returned JSON, look for sandbox/runtime connection fields (names vary slightly by deployment/version). Common patterns:
+   - a sandbox object containing `agent_server_url` (or similar)
+   - a session key such as `session_api_key` (or similar)
+3. Use those values to call the agent server directly:
+   - Base: `{agent_server_url}/api/...`
+   - Header: `X-Session-API-Key: <session_api_key>`
+
+If those fields are not present on the conversation record, list/search sandboxes (`GET /api/v1/sandboxes/search`) and use the sandbox referenced by the conversation to locate the agent server URL + session key.
+
+## Common V1 app server endpoints
+
+The following are the main endpoints implemented in the minimal client:
+
+- `GET /api/v1/users/me` — validate auth and inspect current account
+- `GET /api/v1/app-conversations/search?limit=...` — list recent conversations
+- `GET /api/v1/app-conversations?ids=...` — fetch conversation records by id (batch)
+- `GET /api/v1/app-conversations/count` — count conversations
+- `POST /api/v1/app-conversations` — start a new conversation (creates a sandbox)
+- `GET /api/v1/app-conversations/start-tasks?ids=...` — check async start-task status
+- `GET /api/v1/conversation/{app_conversation_id}/events/search?limit=...` — read conversation events
+- `GET /api/v1/conversation/{app_conversation_id}/events/count` — count events
+- `GET /api/v1/sandboxes/search?limit=...` — list sandboxes
+- `POST /api/v1/sandboxes/{sandbox_id}/pause` / `.../resume` — manage sandbox lifecycle
+- `GET /api/v1/app-conversations/{app_conversation_id}/download` — download trajectory zip
+
+### Start-task vs `app_conversation_id` (common pitfall)
+
+In many deployments, `POST /api/v1/app-conversations` is **asynchronous** and returns a **start-task** object:
+
+- `id` is the **start_task_id**
+- `app_conversation_id` is the id you should use for conversation operations like:
+  - `GET /api/v1/app-conversations/{app_conversation_id}/download`
+  - `GET /api/v1/conversation/{app_conversation_id}/events/...`
+
+If `app_conversation_id` is not present in the initial response, fetch it via:
+
+- `GET /api/v1/app-conversations/start-tasks?ids=<start_task_id>`
+
+If you pass a **start_task_id** to `/download`, you will get `404 Not Found`.
+
+## Common agent server endpoints
+
+These run against `agent_server_url` (not the app server):
+
+- `POST {agent_server_url}/api/bash/execute_bash_command`
+- `GET  {agent_server_url}/api/file/download/<absolute_path>`
+- `POST {agent_server_url}/api/file/upload/<absolute_path>` (multipart)
+- `GET  {agent_server_url}/api/conversations/{conversation_id}/events/search`
+- `GET  {agent_server_url}/api/conversations/{conversation_id}/events/count`
+
+
+### Counting events (recommended approach)
+
+If you need to know how many events a conversation has, you can:
+
+1. **App server count (fastest when working)**
+   - `GET /api/v1/conversation/{app_conversation_id}/events/count`
+2. **Agent server count (reliable fallback)**
+   - `GET {agent_server_url}/api/conversations/{app_conversation_id}/events/count`
+3. **Trajectory zip fallback (heavier, but still one call + gives full payloads)**
+   - `GET /api/v1/app-conversations/{app_conversation_id}/download`
+   - Unzip and count `event_*.json` files
+
+Do **not** rely on the last event `id` to infer the total number of events.
+In the agent-server API, event IDs are UUIDs (not monotonically increasing integers).
+
+## Quick start (Python)
+
+```python
+# Copy `skills/openhands-api-v1/scripts/openhands_api_v1.py` into your project (e.g. as `openhands_api_v1.py`),
+# then import it normally:
+from openhands_api_v1 import OpenHandsV1API
+
+api = OpenHandsV1API()  # uses OPENHANDS_API_KEY
+
+me = api.users_me()
+print(me)
+
+recent = api.app_conversations_search(limit=5)
+print(recent)
+
+api.close()
+```
+
+## CLI examples
+
+Search conversations:
+
+```bash
+export OPENHANDS_API_KEY="..."
+python skills/openhands-api-v1/scripts/openhands_api_v1.py search-conversations --limit 5
+```
+
+Start a conversation from a prompt file:
+
+```bash
+python skills/openhands-api-v1/scripts/openhands_api_v1.py start-conversation \
+  --prompt-file skills/openhands-api-v1/references/example_prompt.md \
+  --repo owner/repo \
+  --branch main
+```
+
+## Notes for AI agents extending this client
+
+- Prefer `.../search` endpoints with a small `limit`.
+- Avoid loops that could generate many API calls.
+- Start conversations only when asked: it may create sandboxes and cost money.
+- For sandbox file operations and command execution, use the agent server endpoints with `X-Session-API-Key`.
+
+See also:
+- `skills/openhands-api-v1/scripts/openhands_api_v1.py`
+- The original inspiration client: `enyst/llm-playground` → `openhands-api-client-v1/scripts/cloud_api_v1.py`

--- a/skills/openhands-api-v1/references/README.md
+++ b/skills/openhands-api-v1/references/README.md
@@ -1,0 +1,19 @@
+# OpenHands Cloud API V1 references
+
+This skill ships a minimal client plus a short list of the most useful endpoints.
+
+The V1 app server routes are served from the OpenHands Cloud app host:
+
+- Base URL (default): `https://app.all-hands.dev`
+- API prefix: `/api/v1`
+
+Key concepts:
+
+- **App server** endpoints use Bearer auth (`Authorization: Bearer <OPENHANDS_API_KEY>`).
+- **Agent server** endpoints are served by the sandbox runtime and use session auth (`X-Session-API-Key`).
+
+If you need deeper, up-to-date definitions, check the OpenHands main repository for the latest server route implementations. In that repo, the V1 app server routes typically live under:
+
+- `openhands/app_server/routes/`
+
+(The legacy V0 API routes live under `openhands/server/routes/`.)

--- a/skills/openhands-api-v1/references/example_prompt.md
+++ b/skills/openhands-api-v1/references/example_prompt.md
@@ -1,0 +1,12 @@
+# Example prompt file (OpenHands V1)
+
+Replace the text below with the task you want OpenHands to perform.
+
+---
+
+Please:
+1) Explain what this repository does.
+2) List the existing test/lint commands you can find.
+3) Propose the smallest possible change to address the issue described in the task.
+
+(Do not run long loops or poll APIs. Keep external calls minimal.)

--- a/skills/openhands-api-v1/scripts/openhands_api_v1.py
+++ b/skills/openhands-api-v1/scripts/openhands_api_v1.py
@@ -1,0 +1,589 @@
+"""OpenHands Cloud API (V1) minimal client.
+
+This file is intentionally:
+- small (easy to copy into other repos)
+- dependency-light (only `httpx`)
+- opinionated in a helpful way (defaults to OpenHands Cloud)
+
+Audience: AI agents.
+
+The V1 API is hosted on the OpenHands app server under:
+  {BASE_URL}/api/v1/...
+
+Typical workflow for common operations:
+1) Discover: GET /api/v1/users/me
+2) List/search conversations: GET /api/v1/app-conversations/search
+3) Start a conversation (creates sandbox): POST /api/v1/app-conversations
+4) Monitor events for a conversation: GET /api/v1/conversation/{id}/events/search
+5) (Optional) download trajectory: GET /api/v1/app-conversations/{id}/download
+
+Note: Some operations happen against the *agent server* running inside a sandbox
+(not the app server). Those endpoints use X-Session-API-Key instead of Bearer auth.
+
+This client purposefully keeps responses as raw dicts/lists so agents can quickly
+adapt it without strict schema maintenance.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+
+DEFAULT_BASE_URL = "https://app.all-hands.dev"
+
+
+# Start-task statuses observed in the wild. These may evolve, so keep this centralized.
+START_TASK_TERMINAL_STATUSES = frozenset(
+    {"READY", "ERROR", "FAILED", "CANCELLED", "DONE", "COMPLETED"}
+)
+
+
+# Safety cap for paging calls. Keeps responses small and consistent across clients.
+AGENT_EVENTS_SEARCH_MAX_LIMIT = 100
+
+
+@dataclass(frozen=True)
+class OpenHandsV1Config:
+    api_key: str
+    base_url: str = DEFAULT_BASE_URL
+
+    @property
+    def api_v1_url(self) -> str:
+        return f"{self.base_url.rstrip('/')}/api/v1"
+
+
+class OpenHandsV1API:
+    """Minimal OpenHands Cloud API V1 client (app server + agent server helpers)."""
+
+    def __init__(self, api_key: str | None = None, base_url: str = DEFAULT_BASE_URL):
+        resolved_key = api_key or os.getenv("OPENHANDS_API_KEY")
+        if not resolved_key:
+            raise ValueError("Missing API key. Set OPENHANDS_API_KEY or pass api_key=...")
+
+        self._cfg = OpenHandsV1Config(api_key=resolved_key, base_url=base_url.rstrip("/"))
+        self._client = httpx.Client(
+            headers={
+                "Authorization": f"Bearer {self._cfg.api_key}",
+                "Content-Type": "application/json",
+            },
+            timeout=30,
+        )
+
+    @property
+    def base_url(self) -> str:
+        return self._cfg.base_url
+
+    @property
+    def api_v1_url(self) -> str:
+        return self._cfg.api_v1_url
+
+    def close(self) -> None:
+        self._client.close()
+
+    # -----------------------------
+    # App server endpoints (Bearer auth)
+    # -----------------------------
+
+    def users_me(self) -> dict[str, Any]:
+        r = self._client.get(f"{self.api_v1_url}/users/me")
+        r.raise_for_status()
+        return r.json()
+
+    def app_conversations_search(self, *, limit: int = 20) -> dict[str, Any]:
+        limit = max(1, int(limit))
+        r = self._client.get(
+            f"{self.api_v1_url}/app-conversations/search", params={"limit": limit}
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def app_conversations_count(self) -> dict[str, Any]:
+        r = self._client.get(f"{self.api_v1_url}/app-conversations/count")
+        r.raise_for_status()
+        return r.json()
+
+    def app_conversations_get_batch(self, *, ids: list[str]) -> list[dict[str, Any]]:
+        if not ids:
+            return []
+        r = self._client.get(f"{self.api_v1_url}/app-conversations", params={"ids": ids})
+        r.raise_for_status()
+        return r.json()
+
+    def app_conversation_get(self, conversation_id: str) -> dict[str, Any] | None:
+        items = self.app_conversations_get_batch(ids=[conversation_id])
+        return items[0] if items else None
+
+    def sandboxes_search(self, *, limit: int = 20) -> dict[str, Any]:
+        limit = max(1, int(limit))
+        r = self._client.get(f"{self.api_v1_url}/sandboxes/search", params={"limit": limit})
+        r.raise_for_status()
+        return r.json()
+
+    def sandbox_specs_search(self, *, limit: int = 20) -> dict[str, Any]:
+        limit = max(1, int(limit))
+        r = self._client.get(
+            f"{self.api_v1_url}/sandbox-specs/search", params={"limit": limit}
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def conversation_events_search(
+        self, conversation_id: str, *, limit: int = 50
+    ) -> dict[str, Any]:
+        limit = max(1, int(limit))
+        r = self._client.get(
+            f"{self.api_v1_url}/conversation/{conversation_id}/events/search",
+            params={"limit": limit},
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def conversation_events_count(self, conversation_id: str) -> dict[str, Any]:
+        r = self._client.get(f"{self.api_v1_url}/conversation/{conversation_id}/events/count")
+        r.raise_for_status()
+        return r.json()
+
+    def app_conversation_start(
+        self,
+        *,
+        initial_message: str,
+        selected_repository: str | None = None,
+        selected_branch: str | None = None,
+        title: str | None = None,
+        run: bool = True,
+    ) -> dict[str, Any]:
+        """Start a new V1 app conversation.
+
+        WARNING: This typically creates a sandbox and may incur costs.
+
+        In many deployments this endpoint is **asynchronous** and returns a **start-task** dict.
+        Common fields:
+        - `id`: the *start_task_id*
+        - `app_conversation_id`: the id to use for `/download` and `/conversation/.../events/...`
+
+        If `app_conversation_id` is missing from the initial response, fetch it via:
+        - `GET /api/v1/app-conversations/start-tasks?ids=<start_task_id>`
+          (see `app_conversation_start_task_get()` / `poll_start_task_until_ready()`).
+
+        The payload structure here mirrors what the V1 app server expects:
+        - initial_message.content is a list of content parts
+        """
+
+        payload: dict[str, Any] = {
+            "initial_message": {
+                "role": "user",
+                # V1 expects `content` as a list of parts, even for a single text message.
+                "content": [{"type": "text", "text": initial_message}],
+                "run": bool(run),
+            }
+        }
+        if selected_repository:
+            payload["selected_repository"] = selected_repository
+        if selected_branch:
+            payload["selected_branch"] = selected_branch
+        if title:
+            payload["title"] = title
+
+        r = self._client.post(f"{self.api_v1_url}/app-conversations", json=payload, timeout=120)
+        r.raise_for_status()
+        return r.json()
+
+    def app_conversations_start_tasks_get_batch(self, *, ids: list[str]) -> list[dict[str, Any]]:
+        if not ids:
+            return []
+        r = self._client.get(
+            f"{self.api_v1_url}/app-conversations/start-tasks", params={"ids": ids}
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def app_conversation_start_task_get(self, task_id: str) -> dict[str, Any] | None:
+        items = self.app_conversations_start_tasks_get_batch(ids=[task_id])
+        return items[0] if items else None
+
+    def sandboxes_pause(self, sandbox_id: str) -> dict[str, Any]:
+        r = self._client.post(f"{self.api_v1_url}/sandboxes/{sandbox_id}/pause", timeout=60)
+        r.raise_for_status()
+        return r.json()
+
+    def sandboxes_resume(self, sandbox_id: str) -> dict[str, Any]:
+        r = self._client.post(f"{self.api_v1_url}/sandboxes/{sandbox_id}/resume", timeout=60)
+        r.raise_for_status()
+        return r.json()
+
+    def app_conversation_download_zip(
+        self, app_conversation_id: str, *, output_file: str | Path
+    ) -> dict[str, Any]:
+        """Download a conversation trajectory zip to disk.
+
+        Note: this endpoint expects the **app_conversation_id** (not the start-task id).
+        """
+        url = f"{self.api_v1_url}/app-conversations/{app_conversation_id}/download"
+        r = self._client.get(url, timeout=60)
+        r.raise_for_status()
+        out = Path(output_file)
+        out.write_bytes(r.content)
+        return {
+            "file": str(out),
+            "size": len(r.content),
+            "content_type": r.headers.get("content-type"),
+        }
+
+    def count_events_via_trajectory_zip(
+        self,
+        app_conversation_id: str,
+        *,
+        zip_file: str | Path,
+        extract_dir: str | Path,
+    ) -> dict[str, Any]:
+        """Fallback event counting: download trajectory zip, extract, count event files.
+
+        This is heavier than calling a count endpoint, but it is still a single API call and
+        also gives you the full exported event payloads.
+
+        Cleanup (optional): this helper writes a zip file and extracts JSON events. If you
+        want to clean up afterwards, you can remove them, e.g.:
+
+        - `zip_path.unlink(missing_ok=True)`
+        - `shutil.rmtree(extract_path, ignore_errors=True)`
+
+        Returns a small summary dict including `event_count`.
+        """
+
+        zip_path = Path(zip_file)
+        extract_path = Path(extract_dir)
+
+        download_meta = self.app_conversation_download_zip(app_conversation_id, output_file=zip_path)
+        extract_path.mkdir(parents=True, exist_ok=True)
+
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            zf.extractall(extract_path)
+
+        event_count = len(list(extract_path.glob("event_*.json")))
+        has_meta = (extract_path / "meta.json").exists()
+
+        return {
+            "event_count": event_count,
+            "has_meta": has_meta,
+            "zip": download_meta,
+            "extract_dir": str(extract_path),
+        }
+
+    # -----------------------------
+    # Agent server endpoints (X-Session-API-Key)
+    # -----------------------------
+
+    @staticmethod
+    def agent_headers(session_api_key: str) -> dict[str, str]:
+        return {"X-Session-API-Key": session_api_key, "Content-Type": "application/json"}
+
+
+    @staticmethod
+    def _agent_event_filter_params(
+        *,
+        timestamp_gte: str | None = None,
+        timestamp_lt: str | None = None,
+        kind: str | None = None,
+        source: str | None = None,
+        body: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+        if timestamp_gte is not None:
+            params["timestamp__gte"] = timestamp_gte
+        if timestamp_lt is not None:
+            params["timestamp__lt"] = timestamp_lt
+        if kind is not None:
+            params["kind"] = kind
+        if source is not None:
+            params["source"] = source
+        if body is not None:
+            params["body"] = body
+        return params
+
+    def agent_events_search(
+        self,
+        *,
+        agent_server_url: str,
+        session_api_key: str,
+        conversation_id: str,
+        limit: int = 50,
+        sort_order: str | None = None,
+        timestamp_gte: str | None = None,
+        timestamp_lt: str | None = None,
+        kind: str | None = None,
+        source: str | None = None,
+        body: str | None = None,
+    ) -> dict[str, Any]:
+        """Search events via the sandbox agent-server.
+
+        Notes:
+        - `limit` is capped at AGENT_EVENTS_SEARCH_MAX_LIMIT to avoid huge responses.
+        - `sort_order` must be one of: "TIMESTAMP", "TIMESTAMP_DESC".
+        - timestamp filters are passed as ISO-8601 strings (e.g. "2026-02-14T21:54:00Z").
+          The server accepts both timezone-aware and naive datetimes.
+        """
+
+        url = f"{agent_server_url.rstrip('/')}/api/conversations/{conversation_id}/events/search"
+        capped_limit = min(AGENT_EVENTS_SEARCH_MAX_LIMIT, max(1, int(limit)))
+        params: dict[str, Any] = {"limit": capped_limit}
+        if sort_order is not None:
+            params["sort_order"] = sort_order
+        params.update(
+            self._agent_event_filter_params(
+                timestamp_gte=timestamp_gte,
+                timestamp_lt=timestamp_lt,
+                kind=kind,
+                source=source,
+                body=body,
+            )
+        )
+
+        r = httpx.get(
+            url,
+            headers=self.agent_headers(session_api_key),
+            params=params,
+            timeout=30,
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def agent_events_count(
+        self,
+        *,
+        agent_server_url: str,
+        session_api_key: str,
+        conversation_id: str,
+        timestamp_gte: str | None = None,
+        timestamp_lt: str | None = None,
+        kind: str | None = None,
+        source: str | None = None,
+        body: str | None = None,
+    ) -> int:
+        """Count events via the sandbox agent-server.
+
+        Timestamp filters are passed as ISO-8601 strings (e.g. "2026-02-14T21:54:00Z").
+        """
+
+        url = f"{agent_server_url.rstrip('/')}/api/conversations/{conversation_id}/events/count"
+        params = self._agent_event_filter_params(
+            timestamp_gte=timestamp_gte,
+            timestamp_lt=timestamp_lt,
+            kind=kind,
+            source=source,
+            body=body,
+        )
+
+        r = httpx.get(
+            url,
+            headers=self.agent_headers(session_api_key),
+            params=params,
+            timeout=30,
+        )
+        r.raise_for_status()
+        return int(r.json())
+
+    def agent_execute_bash(
+        self,
+        *,
+        agent_server_url: str,
+        session_api_key: str,
+        command: str,
+        cwd: str | None = None,
+        timeout_s: int = 30,
+    ) -> dict[str, Any]:
+        url = f"{agent_server_url.rstrip('/')}/api/bash/execute_bash_command"
+        payload: dict[str, Any] = {"command": command, "timeout": int(timeout_s)}
+        if cwd:
+            payload["cwd"] = cwd
+        r = httpx.post(url, headers=self.agent_headers(session_api_key), json=payload, timeout=60)
+        r.raise_for_status()
+        return r.json()
+
+    def agent_download_file(
+        self,
+        *,
+        agent_server_url: str,
+        session_api_key: str,
+        path: str,
+        output_file: str | Path,
+    ) -> dict[str, Any]:
+        p = path if path.startswith("/") else f"/{path}"
+        url = f"{agent_server_url.rstrip('/')}/api/file/download{p}"
+        r = httpx.get(url, headers=self.agent_headers(session_api_key), timeout=30)
+        r.raise_for_status()
+        out = Path(output_file)
+        out.write_bytes(r.content)
+        return {"file": str(out), "size": len(r.content)}
+
+    def agent_upload_text_file(
+        self,
+        *,
+        agent_server_url: str,
+        session_api_key: str,
+        path: str,
+        content: str,
+        content_type: str = "text/plain",
+    ) -> dict[str, Any]:
+        p = path if path.startswith("/") else f"/{path}"
+        url = f"{agent_server_url.rstrip('/')}/api/file/upload{p}"
+        filename = os.path.basename(p)
+        headers = {"X-Session-API-Key": session_api_key}
+        files = {"file": (filename, content.encode("utf-8"), content_type)}
+        r = httpx.post(url, headers=headers, files=files, timeout=30)
+        r.raise_for_status()
+        return r.json() if r.text else {"success": True}
+
+    # -----------------------------
+    # Convenience helpers
+    # -----------------------------
+
+    def app_conversation_start_from_prompt_files(
+        self,
+        prompt_file: str | Path,
+        *,
+        selected_repository: str | None = None,
+        selected_branch: str | None = None,
+        title: str | None = None,
+        append_file: str | Path | None = None,
+        run: bool = True,
+    ) -> dict[str, Any]:
+        main_text = Path(prompt_file).read_text(encoding="utf-8")
+        if append_file and Path(append_file).exists():
+            tail = Path(append_file).read_text(encoding="utf-8")
+            initial = f"{main_text}\n\n{tail}"
+        else:
+            initial = main_text
+
+        return self.app_conversation_start(
+            initial_message=initial,
+            selected_repository=selected_repository,
+            selected_branch=selected_branch,
+            title=title,
+            run=run,
+        )
+
+
+    @staticmethod
+    def _start_task_status(task: dict[str, Any] | None) -> str:
+        return str((task or {}).get("status") or "").upper()
+
+    def poll_start_task_until_ready(
+        self,
+        task_id: str,
+        *,
+        timeout_s: int = 10 * 60,
+        poll_interval_s: float = 2.0,
+        backoff_factor: float = 1.5,
+        max_interval_s: float = 10.0,
+        max_polls: int | None = None,
+    ) -> dict[str, Any]:
+        """Poll a start-task until it reaches a terminal state.
+
+        This is the async companion to `POST /api/v1/app-conversations`.
+
+        It is intentionally *polite*:
+        - sleeps between requests
+        - uses exponential backoff (capped by `max_interval_s`)
+        - supports `max_polls` to cap the total number of API calls
+
+        Terminal statuses are defined in START_TASK_TERMINAL_STATUSES.
+
+        Raises:
+            TimeoutError: if the task doesn't reach a terminal state in time.
+        """
+
+        deadline = time.monotonic() + float(timeout_s)
+        interval = max(0.25, float(poll_interval_s))
+        factor = max(1.0, float(backoff_factor))
+        max_interval = max(interval, float(max_interval_s))
+
+        polls = 0
+        last: dict[str, Any] | None = None
+
+        while True:
+            if max_polls is not None and polls >= int(max_polls):
+                raise TimeoutError(
+                    f"Start task {task_id} did not reach terminal state (max_polls={max_polls}, last={last})"
+                )
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"Start task {task_id} did not reach terminal state in {timeout_s}s (last={last})"
+                )
+
+            last = self.app_conversation_start_task_get(task_id)
+            polls += 1
+
+            status = self._start_task_status(last)
+            if status in START_TASK_TERMINAL_STATUSES:
+                return last or {}
+
+            sleep_s = min(interval, remaining)
+            if sleep_s > 0:
+                time.sleep(sleep_s)
+            interval = min(max_interval, interval * factor)
+
+
+def _cmd_search_conversations(args: argparse.Namespace) -> int:
+    api = OpenHandsV1API(api_key=args.api_key, base_url=args.base_url)
+    try:
+        print(json.dumps(api.app_conversations_search(limit=args.limit), indent=2))
+        return 0
+    finally:
+        api.close()
+
+
+def _cmd_start_conversation(args: argparse.Namespace) -> int:
+    api = OpenHandsV1API(api_key=args.api_key, base_url=args.base_url)
+    try:
+        resp = api.app_conversation_start_from_prompt_files(
+            args.prompt_file,
+            selected_repository=args.repo,
+            selected_branch=args.branch,
+            title=args.title,
+            append_file=args.append_file,
+            run=not args.no_run,
+        )
+        print(json.dumps(resp, indent=2))
+        return 0
+    finally:
+        api.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="openhands_api_v1.py")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_search = sub.add_parser("search-conversations", help="GET /api/v1/app-conversations/search")
+    p_search.add_argument("--api-key", default=None, help="Defaults to OPENHANDS_API_KEY env var")
+    p_search.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    p_search.add_argument("--limit", type=int, default=5)
+    p_search.set_defaults(func=_cmd_search_conversations)
+
+    p_start = sub.add_parser("start-conversation", help="POST /api/v1/app-conversations from a prompt file")
+    p_start.add_argument("--api-key", default=None, help="Defaults to OPENHANDS_API_KEY env var")
+    p_start.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    p_start.add_argument("--prompt-file", required=True)
+    p_start.add_argument("--append-file", default=None)
+    p_start.add_argument("--repo", default=None)
+    p_start.add_argument("--branch", default=None)
+    p_start.add_argument("--title", default=None)
+    p_start.add_argument("--no-run", action="store_true", help="If set, do not auto-run after sending initial message")
+    p_start.set_defaults(func=_cmd_start_conversation)
+
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/openhands-api-v1/scripts/openhands_api_v1.ts
+++ b/skills/openhands-api-v1/scripts/openhands_api_v1.ts
@@ -1,0 +1,248 @@
+/*
+OpenHands Cloud API (V1) minimal client.
+
+Audience: AI agents.
+
+App server (Cloud):
+- Base: https://app.all-hands.dev
+- Prefix: /api/v1
+- Auth: Authorization: Bearer <OPENHANDS_API_KEY>
+
+Agent server (sandbox runtime):
+- Base: {agent_server_url}/api
+- Auth: X-Session-API-Key: <session_api_key>
+
+This is intentionally small and keeps responses mostly untyped (unknown/record)
+so it is easy to adapt.
+*/
+
+export type OpenHandsV1Options = {
+  apiKey: string;
+  baseUrl?: string;
+};
+
+const AGENT_EVENTS_SEARCH_MAX_LIMIT = 100;
+
+
+export class OpenHandsV1API {
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+
+  constructor(opts: OpenHandsV1Options) {
+    if (!opts.apiKey) throw new Error("Missing apiKey");
+    this.apiKey = opts.apiKey;
+    this.baseUrl = (opts.baseUrl ?? "https://app.all-hands.dev").replace(/\/$/, "");
+  }
+
+  private get apiV1Url(): string {
+    return `${this.baseUrl}/api/v1`;
+  }
+
+  private async baseRequest<T>(
+    url: string,
+    init: RequestInit | undefined,
+    headers: Record<string, string>,
+    parseAs: "json" | "blob" = "json",
+  ): Promise<T> {
+    const res = await fetch(url, {
+      ...init,
+      headers: {
+        ...headers,
+        ...(init?.headers ?? {}),
+      },
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`OpenHands API error ${res.status} ${res.statusText}: ${text}`);
+    }
+
+    if (parseAs === "blob") return (await res.blob()) as unknown as T;
+    return (await res.json()) as T;
+  }
+
+  private async request<T>(
+    url: string,
+    init?: RequestInit,
+    parseAs: "json" | "blob" = "json",
+  ): Promise<T> {
+    return await this.baseRequest(
+      url,
+      init,
+      { Authorization: `Bearer ${this.apiKey}`, "Content-Type": "application/json" },
+      parseAs,
+    );
+  }
+
+  // -----------------------------
+  // App server endpoints
+  // -----------------------------
+
+  async usersMe(): Promise<Record<string, unknown>> {
+    return await this.request(`${this.apiV1Url}/users/me`, { method: "GET" });
+  }
+
+  async appConversationsSearch(limit = 20): Promise<Record<string, unknown>> {
+    const safeLimit = Number.isFinite(limit) ? Math.trunc(limit) : 1;
+    const params = new URLSearchParams({ limit: String(Math.max(1, safeLimit)) });
+    return await this.request(`${this.apiV1Url}/app-conversations/search?${params.toString()}`, {
+      method: "GET",
+    });
+  }
+
+  async appConversationsGetBatch(ids: string[]): Promise<Array<Record<string, unknown>>> {
+    if (ids.length === 0) return [];
+    const params = new URLSearchParams();
+    for (const id of ids) params.append("ids", id);
+    return await this.request(`${this.apiV1Url}/app-conversations?${params.toString()}`, {
+      method: "GET",
+    });
+  }
+
+  async conversationEventsCount(appConversationId: string): Promise<number> {
+    const res = await this.request<number>(
+      `${this.apiV1Url}/conversation/${encodeURIComponent(appConversationId)}/events/count`,
+      { method: "GET" },
+    );
+    return Number(res);
+  }
+
+  async appConversationDownloadZip(appConversationId: string): Promise<Blob> {
+    const url = `${this.apiV1Url}/app-conversations/${encodeURIComponent(appConversationId)}/download`;
+    return await this.request<Blob>(url, { method: "GET" }, "blob");
+  }
+
+  async appConversationStart(req: {
+    initialMessage: string;
+    selectedRepository?: string;
+    selectedBranch?: string;
+    title?: string;
+    run?: boolean;
+  }): Promise<Record<string, unknown>> {
+    // NOTE: In many deployments this returns a *start-task* object.
+    // `id` is usually the start_task_id; use `app_conversation_id` (if present)
+    // for `/download` and `/conversation/.../events/...` endpoints.
+    // If `app_conversation_id` is missing, fetch it via:
+    // GET /api/v1/app-conversations/start-tasks?ids=<start_task_id>
+
+    const payload: Record<string, unknown> = {
+      initial_message: {
+        role: "user",
+        // V1 expects `content` as an array of parts, even for a single text message.
+        content: [{ type: "text", text: req.initialMessage }],
+        run: req.run ?? true,
+      },
+    };
+    if (req.selectedRepository) payload.selected_repository = req.selectedRepository;
+    if (req.selectedBranch) payload.selected_branch = req.selectedBranch;
+    if (req.title) payload.title = req.title;
+
+    return await this.request(`${this.apiV1Url}/app-conversations`, {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+  }
+
+  async appConversationsStartTasksGetBatch(ids: string[]): Promise<Array<Record<string, unknown>>> {
+    if (ids.length === 0) return [];
+    const params = new URLSearchParams();
+    for (const id of ids) params.append("ids", id);
+    return await this.request(`${this.apiV1Url}/app-conversations/start-tasks?${params.toString()}`, {
+      method: "GET",
+    });
+  }
+
+  // -----------------------------
+  // Agent server endpoints
+  // -----------------------------
+
+  private async agentRequest<T>(
+    agentServerUrl: string,
+    sessionApiKey: string,
+    path: string,
+    init?: RequestInit,
+  ): Promise<T> {
+    const base = agentServerUrl.replace(/\/$/, "");
+    const url = `${base}${path}`;
+    return await this.baseRequest(
+      url,
+      init,
+      { "X-Session-API-Key": sessionApiKey, "Content-Type": "application/json" },
+      "json",
+    );
+  }
+
+  private buildAgentEventFilterParams(opts?: {
+    timestampGte?: string;
+    timestampLt?: string;
+    kind?: string;
+    source?: string;
+    body?: string;
+  }): URLSearchParams {
+    const params = new URLSearchParams();
+    if (opts?.timestampGte) params.set("timestamp__gte", opts.timestampGte);
+    if (opts?.timestampLt) params.set("timestamp__lt", opts.timestampLt);
+    if (opts?.kind) params.set("kind", opts.kind);
+    if (opts?.source) params.set("source", opts.source);
+    if (opts?.body) params.set("body", opts.body);
+    return params;
+  }
+
+  async agentEventsCount(agentServerUrl: string, sessionApiKey: string, conversationId: string, opts?: {
+    timestampGte?: string;
+    timestampLt?: string;
+    kind?: string;
+    source?: string;
+    body?: string;
+  }): Promise<number> {
+    const qs = this.buildAgentEventFilterParams(opts).toString();
+    const suffix = qs ? `?${qs}` : "";
+
+    const n = await this.agentRequest<number>(
+      agentServerUrl,
+      sessionApiKey,
+      `/api/conversations/${encodeURIComponent(conversationId)}/events/count${suffix}`,
+      { method: "GET" },
+    );
+    return Number(n);
+  }
+
+  async agentEventsSearch(agentServerUrl: string, sessionApiKey: string, conversationId: string, opts?: {
+    limit?: number;
+    sortOrder?: "TIMESTAMP" | "TIMESTAMP_DESC";
+    timestampGte?: string;
+    timestampLt?: string;
+    kind?: string;
+    source?: string;
+    body?: string;
+  }): Promise<Record<string, unknown>> {
+    const params = this.buildAgentEventFilterParams(opts);
+
+    // Cap limit to keep responses small and consistent across clients.
+    const rawLimit = opts?.limit ?? 50;
+    const safeLimit = Number.isFinite(rawLimit) ? Math.trunc(rawLimit) : 1;
+    const limit = Math.max(1, Math.min(AGENT_EVENTS_SEARCH_MAX_LIMIT, safeLimit));
+    params.set("limit", String(limit));
+
+    if (opts?.sortOrder) params.set("sort_order", opts.sortOrder);
+
+    return await this.agentRequest<Record<string, unknown>>(
+      agentServerUrl,
+      sessionApiKey,
+      `/api/conversations/${encodeURIComponent(conversationId)}/events/search?${params.toString()}`,
+      { method: "GET" },
+    );
+  }
+
+  async agentExecuteBash(agentServerUrl: string, sessionApiKey: string, command: string, cwd?: string): Promise<Record<string, unknown>> {
+    const payload: Record<string, unknown> = { command, timeout: 30 };
+    if (cwd) payload.cwd = cwd;
+
+    return await this.agentRequest<Record<string, unknown>>(
+      agentServerUrl,
+      sessionApiKey,
+      `/api/bash/execute_bash_command`,
+      { method: "POST", body: JSON.stringify(payload) },
+    );
+  }
+}

--- a/tests/test_python_scripts_compile.py
+++ b/tests/test_python_scripts_compile.py
@@ -1,0 +1,26 @@
+import py_compile
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestSkillPythonScriptsCompile(unittest.TestCase):
+    def _compile(self, rel_path: str) -> None:
+        src = REPO_ROOT / rel_path
+        self.assertTrue(src.exists(), f"Missing {rel_path}")
+        with tempfile.TemporaryDirectory() as td:
+            cfile = Path(td) / (src.stem + ".pyc")
+            py_compile.compile(str(src), cfile=str(cfile), doraise=True)
+
+    def test_openhands_api_v1_compiles(self) -> None:
+        self._compile("skills/openhands-api-v1/scripts/openhands_api_v1.py")
+
+    def test_babysit_pr_watch_compiles(self) -> None:
+        self._compile("skills/babysit-pr/scripts/gh_pr_watch.py")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2.

## Summary
This PR syncs skill content from PRs opened by @enyst in `OpenHands/extensions` into this repo.

## Changes
- Added `skills/adapt-yourself` (from OpenHands/extensions#66)
- Added `skills/openhands-api-v1` (from OpenHands/extensions#48)
- Added `skills/babysit-pr` (from OpenHands/extensions#69)
- Added `skills/frontend-slides` (from OpenHands/extensions#70)
- Added a minimal `unittest` that compiles the included Python scripts
- Added `.gitignore` for Python bytecode caches

## Testing
- `python -m unittest discover -s tests -p 'test_*.py' -v`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added self-modification playbook skill with extensibility architecture guidance
  * Added GitHub PR automation skill with CI/review monitoring and flaky retry capabilities
  * Added frontend slide generation skill with HTML presentation templates and visual presets
  * Added OpenHands Cloud API v1 client libraries (Python and TypeScript) with sandbox and conversation endpoints

* **Documentation**
  * Comprehensive skill guides, workflow references, architecture documentation, and usage templates
  * API client documentation with quick-start examples and endpoint descriptions

* **Tests**
  * Added Python script compilation verification tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->