### PR TITLE
Refine newsletter skill data collection

### DIFF
--- a/skills/newsletter/SKILL.md
+++ b/skills/newsletter/SKILL.md
@@ -75,7 +75,7 @@ comm -23 <(find . -name '*.md' -not -path './.git/*' | sort) <(git log --all --d
 git worktree list
 
 # Branches with no commits in 7+ days
-git for-each-ref --sort=committerdate --format='%(committerdate:unix) %(committerdate:relative) %(refname:short)' refs/heads/ | awk -v cutoff="$(($(date +%s) - 7*24*60*60))" '$1 <= cutoff { $1=""; sub(/^ /, ""); print }' | head -20
+git for-each-ref --sort=committerdate --format='%(committerdate:unix) %(committerdate:relative) %(refname:short)' refs/heads/ | awk -v cutoff="$(($(date +%s) - 7*24*60*60))" '$1 <= cutoff { sub($1" ", ""); print }' | head -20
 ```
 
 ## Output Format

--- a/skills/newsletter/SKILL.md
+++ b/skills/newsletter/SKILL.md
@@ -36,7 +36,7 @@ git branch -a --sort=-committerdate | head -10
 gh pr list --state open --json number,title,headRefName,author,reviewDecision,statusCheckRollup,mergeable,updatedAt
 
 # In-progress issues
-gh issue list --state open --assignee @me --json number,title,labels,updatedAt
+gh issue list --state open --json number,title,labels,updatedAt
 ```
 
 ### 2. CI/CD & Check Status
@@ -59,16 +59,14 @@ gh api repos/{owner}/{repo}/pulls/comments --jq '.[0:10] | .[] | {pr: .pull_requ
 
 ### 4. Merge Queue
 ```bash
-# PRs that are approved and CI-passing
-gh pr list --state open --json number,title,reviewDecision,statusCheckRollup,mergeable | jq '[.[] | select(.reviewDecision == "APPROVED")]'
+# PRs that are approved, mergeable, and have successful status checks
+gh pr list --state open --json number,title,reviewDecision,statusCheckRollup,mergeable | jq '[.[] | select(.reviewDecision == "APPROVED" and .mergeable == "MERGEABLE" and ([.statusCheckRollup[]? | .state // .conclusion] | all(. == "SUCCESS")))]'
 ```
 
 ### 5. Documentation & Staleness
 ```bash
-# Files not touched in 30+ days that may be stale
-git log --all --diff-filter=M --since="30 days ago" --name-only --pretty=format: -- '*.md' | sort -u > /tmp/recently_modified_docs.txt
-find . -name '*.md' -not -path './.git/*' | sort > /tmp/all_docs.txt
-comm -23 /tmp/all_docs.txt /tmp/recently_modified_docs.txt
+# Markdown files untouched in 30+ days that may be stale
+comm -23 <(find . -name '*.md' -not -path './.git/*' | sort) <(git log --all --diff-filter=AM --since="30 days ago" --name-only --pretty=format: -- '*.md' | sort -u)
 ```
 
 ### 6. Git Worktree / Session Health
@@ -76,8 +74,8 @@ comm -23 /tmp/all_docs.txt /tmp/recently_modified_docs.txt
 # Active worktrees
 git worktree list
 
-# Stale branches (no commits in 7+ days)
-git for-each-ref --sort=committerdate --format='%(committerdate:relative) %(refname:short)' refs/heads/ | head -20
+# Branches with no commits in 7+ days
+git for-each-ref --sort=committerdate --format='%(committerdate:unix) %(committerdate:relative) %(refname:short)' refs/heads/ | awk -v cutoff="$(($(date +%s) - 7*24*60*60))" '$1 <= cutoff { $1=""; sub(/^ /, ""); print }' | head -20
 ```
 
 ## Output Format


### PR DESCRIPTION
## Summary
- broaden newsletter issue collection to include all open issues
- tighten the merge-queue example so it filters for approved, mergeable PRs with successful checks
- improve stale documentation and stale branch examples to better match the intended reporting

## Context
Follow-up to merged PR #5 to address substantive Gemini Code Assist review feedback on `skills/newsletter/SKILL.md`.

## Validation
- ran the updated jq filter against PR data from this repository
- executed the stale documentation and stale branch shell snippets locally to confirm they behave as described


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated issue query to return all open issues without assignee filtering
  * Enhanced merge queue selection with stricter validation for mergeable status and status check verification
  * Optimized command performance for identifying stale Markdown files with simplified pipeline
  * Improved stale branch identification using absolute timestamp-based filtering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->