### PR TITLE
Add Broadsheet Dispatch preset for frontend slides

### DIFF
--- a/skills/frontend-slides/README.md
+++ b/skills/frontend-slides/README.md
@@ -101,6 +101,7 @@ The skill will:
 - **Swiss Modern** — Clean, Bauhaus-inspired, geometric
 - **Soft Pastel** — Friendly, playful, creative
 - **Warm Editorial** — Magazine-style, photographic
+- **Broadsheet Dispatch** — Newspaper-style, status-heavy, review-friendly
 
 ### Specialty
 - **Brutalist** — Raw, bold, attention-grabbing

--- a/skills/frontend-slides/references/STYLE_PRESETS.md
+++ b/skills/frontend-slides/references/STYLE_PRESETS.md
@@ -50,6 +50,7 @@ Each preset lives in its own file so agents can load just the chosen style:
 - **Terminal Green** — Developer-focused, hacker aesthetic ([presets/terminal-green.md](presets/terminal-green.md))
 - **Swiss Modern** — Bauhaus-inspired precision ([presets/swiss-modern.md](presets/swiss-modern.md))
 - **Paper & Ink** — Literary editorial ([presets/paper-ink.md](presets/paper-ink.md))
+- **Broadsheet Dispatch** — Newspaper-style status front page ([presets/broadsheet-dispatch.md](presets/broadsheet-dispatch.md))
 
 ---
 
@@ -69,6 +70,7 @@ Each preset lives in its own file so agents can load just the chosen style:
 | Terminal Green | JetBrains Mono | JetBrains Mono | JetBrains |
 | Swiss Modern | Archivo | Nunito | Google |
 | Paper & Ink | Cormorant Garamond | Source Serif 4 | Google |
+| Broadsheet Dispatch | Cormorant Garamond | Source Serif 4 | Google |
 
 ---
 

--- a/skills/frontend-slides/references/STYLE_PRESETS.md
+++ b/skills/frontend-slides/references/STYLE_PRESETS.md
@@ -43,6 +43,7 @@ Each preset lives in its own file so agents can load just the chosen style:
 - **Pastel Geometry** — Friendly, modern, approachable ([presets/pastel-geometry.md](presets/pastel-geometry.md))
 - **Split Pastel** — Playful, creative ([presets/split-pastel.md](presets/split-pastel.md))
 - **Vintage Editorial** — Personality-driven editorial ([presets/vintage-editorial.md](presets/vintage-editorial.md))
+- **Broadsheet Dispatch** — Newspaper-style status front page ([presets/broadsheet-dispatch.md](presets/broadsheet-dispatch.md))
 
 ### Specialty themes
 
@@ -50,7 +51,6 @@ Each preset lives in its own file so agents can load just the chosen style:
 - **Terminal Green** — Developer-focused, hacker aesthetic ([presets/terminal-green.md](presets/terminal-green.md))
 - **Swiss Modern** — Bauhaus-inspired precision ([presets/swiss-modern.md](presets/swiss-modern.md))
 - **Paper & Ink** — Literary editorial ([presets/paper-ink.md](presets/paper-ink.md))
-- **Broadsheet Dispatch** — Newspaper-style status front page ([presets/broadsheet-dispatch.md](presets/broadsheet-dispatch.md))
 
 ---
 

--- a/skills/frontend-slides/references/WORKFLOW_NEW_PRESENTATION.md
+++ b/skills/frontend-slides/references/WORKFLOW_NEW_PRESENTATION.md
@@ -73,6 +73,7 @@ Users can select a style in **two ways**:
 | Terminal Green | Developer-focused | Dev tools, APIs |
 | Swiss Modern | Minimal, precise | Corporate, data |
 | Paper & Ink | Literary, thoughtful | Storytelling |
+| Broadsheet Dispatch | Newspaper, structured, high-density | Status reports, reviews |
 
 ### Step 2.0: Style Path Selection
 
@@ -97,6 +98,7 @@ First, ask how the user wants to choose their style:
   - "Dark Botanical" — Elegant dark with soft abstract shapes
   - "Notebook Tabs" — Editorial paper look with colorful section tabs
   - "Pastel Geometry" — Friendly pastels with decorative pills
+  - "Broadsheet Dispatch" — Newspaper front page for status digests and review roundups
 
 (If user picks one, skip to Phase 3. If they want to see more options, show additional presets or proceed to guided discovery.)
 
@@ -125,7 +127,7 @@ Based on their mood selection, generate **3 distinct style previews** as mini HT
 
 | Mood | Style Options |
 |------|---------------|
-| Impressed/Confident | "Bold Signal", "Electric Studio", "Dark Botanical" |
+| Impressed/Confident | "Bold Signal", "Electric Studio", "Broadsheet Dispatch" |
 | Excited/Energized | "Creative Voltage", "Neon Cyber", "Split Pastel" |
 | Calm/Focused | "Notebook Tabs", "Paper & Ink", "Swiss Modern" |
 | Inspired/Moved | "Dark Botanical", "Vintage Editorial", "Pastel Geometry" |

--- a/skills/frontend-slides/references/presets/broadsheet-dispatch.md
+++ b/skills/frontend-slides/references/presets/broadsheet-dispatch.md
@@ -7,7 +7,7 @@
 **Typography:**
 - Display: `Cormorant Garamond` (700) or `Bodoni Moda` (700) for mastheads and banner headlines
 - Body: `Source Serif 4` (400/600)
-- Labels / metadata: `IBM Plex Sans Condensed` or `Arial Narrow`
+- Labels / metadata: `IBM Plex Sans Condensed`
 
 **Colors:**
 ```css

--- a/skills/frontend-slides/references/presets/broadsheet-dispatch.md
+++ b/skills/frontend-slides/references/presets/broadsheet-dispatch.md
@@ -1,0 +1,40 @@
+# Broadsheet Dispatch
+
+**Vibe:** Newspaper front page, authoritative, status-rich, editorial
+
+**Layout:** Broadsheet grid with a metadata rail, ticker strip, lead story area, sidebars, and classified-style notices. Each slide should still fit exactly in the viewport; think “front page compressed into one screen,” not an infinitely scrolling article.
+
+**Typography:**
+- Display: `Cormorant Garamond` (700) or `Bodoni Moda` (700) for mastheads and banner headlines
+- Body: `Source Serif 4` (400/600)
+- Labels / metadata: `IBM Plex Sans Condensed` or `Arial Narrow`
+
+**Colors:**
+```css
+:root {
+    --bg-paper: #f6efe2;
+    --ink: #191713;
+    --text-muted: #6b6357;
+    --rule: #1f1a15;
+    --accent-crimson: #a32622;
+    --accent-blue: #294663;
+    --accent-green: #2d6b42;
+}
+```
+
+**Signature Elements:**
+- Oversized centered masthead with top metadata rail
+- Black ticker strip for all-caps headlines
+- Large all-caps lead headline with tight tracking
+- Multi-column article grids, drop caps, pull quotes
+- Boxed sidebars, status cards, and classified-style notices
+- Narrow uppercase status badges in red / blue / green
+- **No illustrations—use borders, rules, boxes, and typography as the visual system**
+
+**Best For:**
+- Status newsletters
+- Technical weekly digests
+- PR / issue roundups
+- Release-room briefings
+
+---


### PR DESCRIPTION
## Summary
- add a new `Broadsheet Dispatch` preset tailored for newspaper-style status and review digests
- document the preset in `STYLE_PRESETS.md` and `WORKFLOW_NEW_PRESENTATION.md`
- mention the new style in the frontend-slides README

## Why
This adds a first-class preset for the kind of broadsheet / dispatch layout used for technical newsletters, PR roundups, and review dashboards.

## Testing
- docs-only change; reviewed rendered markdown locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced "Broadsheet Dispatch" presentation style with a newspaper front-page look, typographic emphasis, and status-focused elements.
  * Added as a selectable preset when creating presentations and recommended for the "Impressed/Confident" mood.
  * Included matching font pairing guidance (Cormorant Garamond display, Source Serif 4 body) for the new style.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->