### PR TITLE
Add OpenHands conversation export skill

### DIFF
--- a/skills/openhands-conversation-export/README.md
+++ b/skills/openhands-conversation-export/README.md
@@ -1,0 +1,43 @@
+# openhands-conversation-export
+
+Export an OpenHands Cloud conversation's event stream to JSON and render it into a human-readable Markdown transcript.
+
+## Included tools
+
+- `scripts/export_conversation.py` - fetches conversation details and paginated events from OpenHands Cloud
+- `scripts/truncate_json.py` - redacts known secrets and truncates oversized strings for safer sharing
+- `scripts/render_markdown.py` - renders a readable transcript with messages inline and tool activity in collapsed blocks
+- `scripts/redaction.py` - shared redaction helpers used by the renderer and truncation script
+
+All scripts are stdlib-only Python.
+
+## Quick start
+
+From the repository root:
+
+```bash
+export OPENHANDS_API_KEY=...
+
+# 1) Fetch full raw event stream
+python3 skills/openhands-conversation-export/scripts/export_conversation.py \
+  --conversation-id 2c6ec633e00c4c5da99601de500e5752 \
+  --out tmp/2c6ec633e00c4c5da99601de500e5752.raw.json
+
+# 2) Create a smaller redacted copy for sharing/committing
+python3 skills/openhands-conversation-export/scripts/truncate_json.py \
+  --input-path tmp/2c6ec633e00c4c5da99601de500e5752.raw.json \
+  --output-path tmp/2c6ec633e00c4c5da99601de500e5752.truncated.json
+
+# 3) Render a markdown transcript
+python3 skills/openhands-conversation-export/scripts/render_markdown.py \
+  --input-path tmp/2c6ec633e00c4c5da99601de500e5752.truncated.json \
+  --output-path tmp/2c6ec633e00c4c5da99601de500e5752.md
+```
+
+## Notes
+
+- A conversation id is the final path segment from a conversation URL like `https://app.all-hands.dev/conversations/<conversation-id>`.
+- The exporter automatically falls back to the per-conversation runtime URL when the app host returns an error page or non-JSON response for `/events`.
+- Review raw exports before sharing them. Even with redaction, transcripts can still contain sensitive project context.
+
+See `references/WORKFLOW.md` for a more detailed playbook.

--- a/skills/openhands-conversation-export/SKILL.md
+++ b/skills/openhands-conversation-export/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: openhands-conversation-export
+description: Export an OpenHands Cloud conversation to JSON and render a readable markdown transcript. Use when the user wants to export/share an OpenHands conversation, inspect conversation events, make a redacted truncated transcript for committing, or turn a conversation URL/id into a markdown transcript.
+triggers:
+- export openhands conversation
+- openhands conversation export
+- render conversation transcript
+- export conversation transcript
+- download conversation events
+- app.all-hands.dev/conversations/
+---
+
+# OpenHands conversation export
+
+Use this skill to export an OpenHands Cloud conversation's event stream, optionally create a redacted truncated JSON for sharing, and render a human-readable markdown transcript.
+
+## Inputs
+
+You usually need:
+
+- a conversation id, or a conversation URL like `https://app.all-hands.dev/conversations/<conversation-id>`
+- `OPENHANDS_API_KEY`
+- optionally `OPENHANDS_APP_BASE` when the deployment is not `https://app.all-hands.dev`
+
+If the user only gives a URL, extract the final path segment as the conversation id.
+
+## Default workflow
+
+1. Pick an output directory and filenames.
+2. Export the raw event stream with `scripts/export_conversation.py`.
+3. If the result may be shared or committed, run `scripts/truncate_json.py` to redact known secrets and shorten long payloads.
+4. Render markdown with `scripts/render_markdown.py`.
+5. Inspect the generated markdown before sending or committing it.
+
+## Commands
+
+Export raw JSON:
+
+```bash
+python3 <this-skill-path>/scripts/export_conversation.py \
+  --conversation-id <conversation-id> \
+  --out <output-dir>/<conversation-id>.raw.json
+```
+
+Create a smaller redacted JSON copy:
+
+```bash
+python3 <this-skill-path>/scripts/truncate_json.py \
+  --input-path <output-dir>/<conversation-id>.raw.json \
+  --output-path <output-dir>/<conversation-id>.truncated.json
+```
+
+Render markdown transcript:
+
+```bash
+python3 <this-skill-path>/scripts/render_markdown.py \
+  --input-path <output-dir>/<conversation-id>.truncated.json \
+  --output-path <output-dir>/<conversation-id>.md
+```
+
+If you need maximum fidelity for local debugging, you can render from the raw JSON instead of the truncated copy, but do not share the raw export without checking for sensitive content.
+
+## Notes
+
+- `export_conversation.py` first tries the app API under `/api/conversations/...`.
+- If the app host returns non-JSON or an error page for `/events`, the exporter automatically falls back to the conversation-specific runtime URL using `session_api_key` from the conversation details.
+- `render_markdown.py` keeps user/agent messages readable and groups tool calls/results in collapsed `<details>` blocks.
+- `truncate_json.py` redacts known API/session keys and shortens very long strings so exports are easier to review and commit.
+
+## Safety
+
+- Treat raw exports as sensitive. Tool output can contain secrets, tokens, URLs with embedded credentials, or other private context.
+- Prefer the truncated JSON plus rendered markdown for anything that leaves the local workspace.
+- If you are exporting a conversation for a public PR or issue, mention that the transcript was generated from an OpenHands conversation export and review the redacted output manually.
+
+## References
+
+- Human-oriented usage notes: `README.md`
+- Detailed workflow and troubleshooting: `references/WORKFLOW.md`

--- a/skills/openhands-conversation-export/references/WORKFLOW.md
+++ b/skills/openhands-conversation-export/references/WORKFLOW.md
@@ -1,0 +1,58 @@
+# Workflow
+
+## When to use this skill
+
+Use this skill when you need to:
+
+- turn an OpenHands conversation into a readable transcript
+- inspect or archive the event stream behind a conversation
+- prepare a conversation export for a PR, issue, or design review
+- share a reproducible agent run without pasting the raw event payload directly
+
+## Prerequisites
+
+- Python 3 available in the runtime
+- `OPENHANDS_API_KEY` set in the environment
+- a conversation id or URL
+
+## Recommended process
+
+1. Derive the conversation id.
+   - If the user gives a URL, use the last path segment.
+2. Choose an output directory.
+   - Prefer a temp or scratch directory unless the user explicitly wants committed artifacts.
+3. Export raw JSON.
+4. Create a truncated copy before sharing or committing.
+5. Render markdown from the truncated copy.
+6. Open the markdown and spot-check the output.
+   - Confirm title/metadata look right.
+   - Confirm tool output was truncated where needed.
+   - Confirm obvious secrets were redacted.
+
+## Troubleshooting
+
+### `OPENHANDS_API_KEY is required`
+
+Set the environment variable before running the exporter.
+
+### The app `/events` endpoint returns HTML or an error
+
+This is expected on some deployments. The exporter already retries using the conversation-specific runtime URL plus `session_api_key` from the conversation details.
+
+### You only have a conversation URL
+
+Use the final segment after `/conversations/` as `--conversation-id`.
+
+### The export is too large to review comfortably
+
+Run `truncate_json.py` with a smaller `--max-len`, `--head`, or `--tail`.
+
+### The markdown transcript is still too noisy
+
+Render from the truncated JSON, not the raw export. The renderer already removes several internal noise events and groups tool activity into collapsed sections.
+
+## Sharing guidance
+
+- Do not post the raw export publicly unless the user explicitly wants that.
+- Prefer sharing the rendered markdown plus, if needed, the truncated JSON.
+- If you include the transcript in a PR or issue, describe it as an AI-generated OpenHands conversation export reviewed by the agent on the user's behalf.

--- a/skills/openhands-conversation-export/scripts/export_conversation.py
+++ b/skills/openhands-conversation-export/scripts/export_conversation.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Export an OpenHands Cloud conversation's events to JSON.
+
+This script is intentionally dependency-free (stdlib-only).
+
+It uses the Cloud management API:
+  GET {base_url}/api/conversations/{conversation_id}
+  GET {base_url}/api/conversations/{conversation_id}/events
+
+If the app host returns an error page / non-JSON, it will fall back to the
+conversation-specific runtime URL from the conversation details (and include
+X-Session-API-Key).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, Iterable, Optional, Tuple
+
+
+DEFAULT_BASE_URL = "https://app.all-hands.dev"
+MAX_LIMIT = 100
+
+
+def _json_request(
+    url: str,
+    *,
+    api_key: str,
+    session_key: Optional[str] = None,
+    timeout_s: int = 60,
+) -> Any:
+    req = urllib.request.Request(url)
+    req.add_header("Authorization", f"Bearer {api_key}")
+    req.add_header("Accept", "application/json")
+    if session_key:
+        req.add_header("X-Session-API-Key", session_key)
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+            raw = resp.read()
+            ctype = resp.headers.get("Content-Type", "")
+    except urllib.error.HTTPError as e:
+        raw = e.read() if hasattr(e, "read") else b""
+        ctype = e.headers.get("Content-Type", "") if e.headers else ""
+        raise RuntimeError(
+            f"HTTP {e.code} for {url} (content-type={ctype!r} body_prefix={raw[:200]!r})"
+        ) from e
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"Request failed for {url} ({e})") from e
+
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        raise RuntimeError(
+            f"Non-JSON response for {url} (content-type={ctype!r} body_prefix={raw[:200]!r})"
+        ) from e
+
+
+def _build_url(base: str, path: str, params: Optional[Dict[str, Any]] = None) -> str:
+    base = base.rstrip("/")
+    path = path if path.startswith("/") else f"/{path}"
+    url = f"{base}{path}"
+    if params:
+        q = urllib.parse.urlencode({k: v for k, v in params.items() if v is not None})
+        url = f"{url}?{q}"
+    return url
+
+
+def get_conversation_details(
+    *, base_url: str, conversation_id: str, api_key: str
+) -> Dict[str, Any]:
+    url = _build_url(base_url, f"/api/conversations/{conversation_id}")
+    data = _json_request(url, api_key=api_key)
+    if not isinstance(data, dict):
+        raise RuntimeError(f"Expected dict for conversation details, got {type(data)}")
+    return data
+
+
+def iter_conversation_events(
+    *,
+    base_url: str,
+    conversation_id: str,
+    api_key: str,
+    runtime_url: Optional[str],
+    session_key: Optional[str],
+    start_id: int = 0,
+    limit: int = MAX_LIMIT,
+    sleep_s: float = 0.0,
+) -> Iterable[Dict[str, Any]]:
+    limit = max(1, min(MAX_LIMIT, int(limit)))
+
+    def fetch_page(page_start: int) -> Tuple[list[Dict[str, Any]], bool]:
+        params = {"start_id": page_start, "limit": limit}
+        url = _build_url(base_url, f"/api/conversations/{conversation_id}/events", params)
+        try:
+            payload = _json_request(url, api_key=api_key)
+        except RuntimeError:
+            if not runtime_url or not session_key:
+                raise
+            runtime_events_url = _build_url(
+                runtime_url,
+                "/events",
+                {"start_id": page_start, "limit": limit},
+            )
+            payload = _json_request(
+                runtime_events_url, api_key=api_key, session_key=session_key
+            )
+
+        events = payload.get("events") if isinstance(payload, dict) else None
+        if not isinstance(events, list):
+            raise RuntimeError(f"Unexpected events payload shape: {type(payload)}")
+        has_more = bool(payload.get("has_more")) if isinstance(payload, dict) else False
+        return events, has_more
+
+    next_start = start_id
+    while True:
+        events, has_more = fetch_page(next_start)
+        if not events:
+            break
+
+        for e in events:
+            if isinstance(e, dict):
+                yield e
+
+        next_start = int(events[-1].get("id", next_start)) + 1
+        if not has_more:
+            break
+        if sleep_s:
+            time.sleep(sleep_s)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Export OpenHands conversation events to JSON")
+    parser.add_argument("--conversation-id", required=True)
+    parser.add_argument(
+        "--base-url",
+        default=os.getenv("OPENHANDS_APP_BASE", DEFAULT_BASE_URL),
+        help="OpenHands app base URL (default: https://app.all-hands.dev)",
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        help="Output JSON file path",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=MAX_LIMIT,
+        help="Events page size (1-100, default 100)",
+    )
+    parser.add_argument(
+        "--sleep-s",
+        type=float,
+        default=0.0,
+        help="Optional sleep between pages (seconds)",
+    )
+
+    args = parser.parse_args()
+
+    api_key = os.getenv("OPENHANDS_API_KEY")
+    if not api_key:
+        print("OPENHANDS_API_KEY is required", file=sys.stderr)
+        return 2
+
+    details = get_conversation_details(
+        base_url=args.base_url, conversation_id=args.conversation_id, api_key=api_key
+    )
+    runtime_url = details.get("url")
+    session_key = details.get("session_api_key")
+
+    events = list(
+        iter_conversation_events(
+            base_url=args.base_url,
+            conversation_id=args.conversation_id,
+            api_key=api_key,
+            runtime_url=runtime_url,
+            session_key=session_key,
+            start_id=0,
+            limit=args.limit,
+            sleep_s=args.sleep_s,
+        )
+    )
+
+    out_obj = {
+        "exported_at": dt.datetime.now(tz=dt.timezone.utc).isoformat(),
+        "base_url": args.base_url,
+        "conversation": details,
+        "events": events,
+    }
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.out)), exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as f:
+        json.dump(out_obj, f, ensure_ascii=False, indent=2)
+
+    print(
+        f"Wrote {len(events)} events to {args.out} (status={details.get('status')!r}, title={details.get('title')!r})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/openhands-conversation-export/scripts/export_conversation.py
+++ b/skills/openhands-conversation-export/scripts/export_conversation.py
@@ -126,13 +126,22 @@ def iter_conversation_events(
         if not events:
             break
 
+        last_event_id: Optional[int] = None
+        if has_more:
+            last_event_id = events[-1].get("id")
+            if not isinstance(last_event_id, int):
+                raise RuntimeError(
+                    f"Expected integer id on last event when has_more=true, got {last_event_id!r}"
+                )
+
         for e in events:
             if isinstance(e, dict):
                 yield e
 
-        next_start = int(events[-1].get("id", next_start)) + 1
         if not has_more:
             break
+
+        next_start = last_event_id + 1
         if sleep_s:
             time.sleep(sleep_s)
 

--- a/skills/openhands-conversation-export/scripts/redaction.py
+++ b/skills/openhands-conversation-export/scripts/redaction.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import re
+
+
+REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"\bghu_[A-Za-z0-9_]{20,}\b"), "<redacted-github-token>"),
+    (re.compile(r"\bghp_[A-Za-z0-9_]{20,}\b"), "<redacted-github-token>"),
+    (re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"), "<redacted-github-token>"),
+    (re.compile(r"(https?://)([^/@\s]+)@github\.com"), r"\1<redacted>@github.com"),
+    (re.compile(r"(Authorization:\s*Bearer\s+)([^\s\"]+)", re.IGNORECASE), r"\1<redacted>"),
+]
+
+
+def redact_secrets(s: str) -> str:
+    for pat, repl in REDACTION_PATTERNS:
+        s = pat.sub(repl, s)
+    return s

--- a/skills/openhands-conversation-export/scripts/render_markdown.py
+++ b/skills/openhands-conversation-export/scripts/render_markdown.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Render a conversation JSON export to a human-readable markdown transcript.
+
+Output focuses on readability:
+- Messages are shown plainly.
+- Tool calls / tool results are wrapped in collapsed <details> blocks.
+- Tool results are truncated (first N + last N characters).
+
+Input format is the output of export_conversation.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+from typing import Any, Dict, List, Optional
+
+from redaction import redact_secrets
+
+
+def _get_text(event: Dict[str, Any]) -> str:
+    args = event.get("args")
+    if isinstance(args, dict):
+        c = args.get("content")
+        if isinstance(c, str) and c.strip():
+            return c
+
+    content = event.get("content")
+    if isinstance(content, str) and content.strip():
+        return content
+
+    msg = event.get("message")
+    if isinstance(msg, str) and msg.strip():
+        return msg
+
+    return ""
+
+
+def _truncate(s: str, head: int, tail: int) -> str:
+    s = redact_secrets(s)
+    head = max(0, head)
+    tail = max(0, tail)
+
+    if len(s) <= head + tail + 20:
+        return s
+
+    removed = len(s) - (head + tail)
+    prefix = s[:head]
+    suffix = "" if tail == 0 else s[-tail:]
+    return f"{prefix}...<truncated {removed} chars>...{suffix}"
+
+
+def _fmt_ts(ts: Optional[str]) -> str:
+    if not ts:
+        return ""
+    try:
+        t = ts.replace("Z", "+00:00")
+        d = dt.datetime.fromisoformat(t)
+        return d.astimezone(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+    except ValueError:
+        return ts
+
+
+def _safe_json(obj: Any) -> str:
+    return redact_secrets(json.dumps(obj, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+def is_chat_message(event: Dict[str, Any]) -> bool:
+    if event.get("source") not in {"user", "agent"}:
+        return False
+    if event.get("action") != "message":
+        return False
+    return bool(_get_text(event).strip())
+
+
+def is_noise_event(event: Dict[str, Any]) -> bool:
+    src = event.get("source")
+    action = event.get("action")
+    obs = event.get("observation")
+
+    # Environment state-change events are usually noisy and add little value.
+    if src == "environment" and obs == "agent_state_changed":
+        return True
+
+    # User recall events are internal plumbing (not user-authored messages).
+    if src == "user" and action == "recall":
+        return True
+
+    # Agent system prompt injection is rarely useful in a transcript.
+    if src == "agent" and action == "system":
+        return True
+
+    # Misc empty environment observations.
+    if src == "environment" and (obs in {None, "null"}) and not _get_text(event).strip():
+        return True
+
+    # Pure agent state toggles.
+    if src == "environment" and action == "change_agent_state":
+        return True
+
+    return False
+
+
+def render_chat_message(event: Dict[str, Any]) -> str:
+    eid = event.get("id")
+    ts = _fmt_ts(event.get("timestamp"))
+    src = event.get("source")
+    role = "User" if src == "user" else "Assistant" if src == "agent" else str(src)
+
+    header_bits = [role]
+    if ts:
+        header_bits.append(ts)
+    if isinstance(eid, int):
+        header_bits.append(f"id={eid}")
+
+    text = _get_text(event).strip()
+    return "\n".join([f"### {' · '.join(header_bits)}", "", text, ""])
+
+
+def render_tool_event(event: Dict[str, Any], *, tool_call_by_id: Dict[int, Dict[str, Any]], head: int, tail: int) -> str:
+    eid = event.get("id")
+    ts = _fmt_ts(event.get("timestamp"))
+    src = event.get("source") or "event"
+
+    header_bits: List[str] = [f"{src}"]
+    if ts:
+        header_bits.append(ts)
+    if isinstance(eid, int):
+        header_bits.append(f"id={eid}")
+
+    if "action" in event and event.get("action") is not None:
+        action = event.get("action")
+        if isinstance(action, str):
+            header_bits.append(f"action={action}")
+
+        body: List[str] = []
+        body.append(f"#### {' · '.join(header_bits)}")
+        body.append("")
+        body.append("```json")
+        body.append(
+            _safe_json({k: event.get(k) for k in ("action", "args", "timeout") if k in event})
+        )
+        body.append("```")
+        body.append("")
+        return "\n".join(body)
+
+    if "observation" in event and event.get("observation") is not None:
+        obs = event.get("observation")
+        cause = event.get("cause")
+        if isinstance(obs, str):
+            header_bits.append(f"observation={obs}")
+        if isinstance(cause, int):
+            header_bits.append(f"cause={cause}")
+            cause_evt = tool_call_by_id.get(cause)
+            cause_action = (cause_evt or {}).get("action")
+            if isinstance(cause_action, str):
+                header_bits.append(f"cause_action={cause_action}")
+
+        content = _get_text(event)
+        content = _truncate(content, head=head, tail=tail) if content else ""
+
+        body = []
+        body.append(f"#### {' · '.join(header_bits)}")
+        if content:
+            body.append("")
+            body.append("```text")
+            body.append(content.rstrip())
+            body.append("```")
+
+        extras = event.get("extras")
+        if extras:
+            body.append("")
+            body.append("```json")
+            body.append(_safe_json(extras))
+            body.append("```")
+
+        body.append("")
+        return "\n".join(body)
+
+    # Fallback: unknown event shape
+    text = _get_text(event)
+    if not text:
+        return ""
+    text = _truncate(text, head=head, tail=tail)
+    return "\n".join([f"#### {' · '.join(header_bits)}", "", "```text", text.rstrip(), "```", ""]) 
+
+
+def render_tools_block(events: List[Dict[str, Any]], *, tool_call_by_id: Dict[int, Dict[str, Any]], head: int, tail: int) -> str:
+    if not events:
+        return ""
+
+    lines: List[str] = []
+    lines.append(f"<details>\n<summary>Tool calls / results ({len(events)} events)</summary>\n")
+    for e in events:
+        chunk = render_tool_event(e, tool_call_by_id=tool_call_by_id, head=head, tail=tail)
+        if chunk.strip():
+            lines.append(chunk)
+    lines.append("</details>\n")
+    return "\n".join(lines)
+
+
+def render_markdown(payload: Dict[str, Any], *, head: int, tail: int) -> str:
+    convo = payload.get("conversation") if isinstance(payload, dict) else None
+    events = payload.get("events") if isinstance(payload, dict) else None
+
+    if not isinstance(convo, dict) or not isinstance(events, list):
+        raise ValueError("Input JSON does not look like an export_conversation.py payload")
+
+    title = convo.get("title") or convo.get("conversation_id") or "Conversation"
+
+    tool_calls: Dict[int, Dict[str, Any]] = {}
+    for e in events:
+        if not isinstance(e, dict) or not isinstance(e.get("id"), int):
+            continue
+        action = e.get("action")
+        if action is None or action == "message":
+            continue
+        tool_calls[int(e["id"])] = e
+
+    out: List[str] = []
+    out.append(f"# {title}\n")
+    out.append("## Metadata\n")
+    out.append(f"- Conversation ID: `{convo.get('conversation_id')}`")
+    if convo.get("selected_repository"):
+        out.append(f"- Repo: `{convo.get('selected_repository')}`")
+    if convo.get("selected_branch"):
+        out.append(f"- Branch: `{convo.get('selected_branch')}`")
+    if convo.get("created_at"):
+        out.append(f"- Created: `{convo.get('created_at')}`")
+    if convo.get("last_updated_at"):
+        out.append(f"- Last updated: `{convo.get('last_updated_at')}`")
+    if convo.get("status"):
+        out.append(f"- Status: `{convo.get('status')}`")
+    out.append("")
+
+    out.append("## Transcript\n")
+
+    preamble_tools: List[Dict[str, Any]] = []
+    pending_tools: List[Dict[str, Any]] = []
+    seen_first_message = False
+
+    for e in events:
+        if not isinstance(e, dict):
+            continue
+        if is_noise_event(e):
+            continue
+
+        if is_chat_message(e):
+            if not seen_first_message:
+                tools_block = render_tools_block(
+                    preamble_tools, tool_call_by_id=tool_calls, head=head, tail=tail
+                )
+                if tools_block.strip():
+                    out.append(tools_block)
+                seen_first_message = True
+            else:
+                tools_block = render_tools_block(
+                    pending_tools, tool_call_by_id=tool_calls, head=head, tail=tail
+                )
+                if tools_block.strip():
+                    out.append(tools_block)
+                pending_tools = []
+
+            out.append(render_chat_message(e))
+            continue
+
+        if seen_first_message:
+            pending_tools.append(e)
+        else:
+            preamble_tools.append(e)
+
+    tools_block = render_tools_block(
+        pending_tools, tool_call_by_id=tool_calls, head=head, tail=tail
+    )
+    if tools_block.strip():
+        out.append(tools_block)
+
+    return "\n".join(out).rstrip() + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render conversation JSON to markdown")
+    parser.add_argument(
+        "--input-path",
+        dest="in_path",
+        required=True,
+        help="Input JSON file path",
+    )
+    parser.add_argument(
+        "--output-path",
+        dest="out_path",
+        required=True,
+        help="Output markdown file path",
+    )
+    parser.add_argument("--head", type=int, default=100)
+    parser.add_argument("--tail", type=int, default=100)
+    args = parser.parse_args()
+
+    with open(args.in_path, "r", encoding="utf-8") as f:
+        payload = json.load(f)
+
+    md = render_markdown(payload, head=args.head, tail=args.tail)
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.out_path)), exist_ok=True)
+    with open(args.out_path, "w", encoding="utf-8") as f:
+        f.write(md)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/openhands-conversation-export/scripts/render_markdown.py
+++ b/skills/openhands-conversation-export/scripts/render_markdown.py
@@ -92,8 +92,13 @@ def is_noise_event(event: Dict[str, Any]) -> bool:
     if src == "agent" and action == "system":
         return True
 
-    # Misc empty environment observations.
-    if src == "environment" and (obs in {None, "null"}) and not _get_text(event).strip():
+    # Misc empty environment observations with no action payload.
+    if (
+        src == "environment"
+        and action in {None, "null"}
+        and obs in {None, "null"}
+        and not _get_text(event).strip()
+    ):
         return True
 
     # Pure agent state toggles.
@@ -271,8 +276,9 @@ def render_markdown(payload: Dict[str, Any], *, head: int, tail: int) -> str:
         else:
             preamble_tools.append(e)
 
+    remaining_tools = pending_tools if seen_first_message else preamble_tools
     tools_block = render_tools_block(
-        pending_tools, tool_call_by_id=tool_calls, head=head, tail=tail
+        remaining_tools, tool_call_by_id=tool_calls, head=head, tail=tail
     )
     if tools_block.strip():
         out.append(tools_block)

--- a/skills/openhands-conversation-export/scripts/truncate_json.py
+++ b/skills/openhands-conversation-export/scripts/truncate_json.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Create a truncated copy of a conversation JSON export.
+
+This is meant to make large tool outputs easier to commit and work with.
+
+Truncation strategy:
+- For any string longer than --max-len, replace it with:
+    first --head chars + "...<truncated N chars>..." + last --tail chars
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Any
+
+from redaction import redact_secrets
+
+
+SENSITIVE_KEYS = {
+    "session_api_key",
+    "api_key",
+    "llm_api_key",
+}
+
+
+def truncate_str(s: str, *, max_len: int, head: int, tail: int) -> str:
+    s = redact_secrets(s)
+    head = max(0, head)
+    tail = max(0, tail)
+
+    if len(s) <= max_len:
+        return s
+
+    if head + tail >= max_len:
+        head = max(0, max_len // 2)
+        tail = max(0, max_len - head)
+
+    removed = len(s) - (head + tail)
+    prefix = s[:head]
+    suffix = "" if tail == 0 else s[-tail:]
+    return f"{prefix}...<truncated {removed} chars>...{suffix}"
+
+
+def truncate_obj(obj: Any, *, max_len: int, head: int, tail: int) -> Any:
+    if isinstance(obj, str):
+        return truncate_str(obj, max_len=max_len, head=head, tail=tail)
+    if isinstance(obj, list):
+        return [truncate_obj(v, max_len=max_len, head=head, tail=tail) for v in obj]
+    if isinstance(obj, dict):
+        out: dict[str, Any] = {}
+        for k, v in obj.items():
+            if k in SENSITIVE_KEYS and isinstance(v, str) and v:
+                out[k] = "<redacted>"
+                continue
+            out[k] = truncate_obj(v, max_len=max_len, head=head, tail=tail)
+        return out
+    return obj
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Truncate long strings in JSON")
+    parser.add_argument(
+        "--input-path",
+        dest="in_path",
+        required=True,
+        help="Input JSON file path",
+    )
+    parser.add_argument(
+        "--output-path",
+        dest="out_path",
+        required=True,
+        help="Output JSON file path",
+    )
+    parser.add_argument("--max-len", type=int, default=5000)
+    parser.add_argument("--head", type=int, default=100)
+    parser.add_argument("--tail", type=int, default=100)
+    args = parser.parse_args()
+
+    with open(args.in_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    truncated = truncate_obj(data, max_len=args.max_len, head=args.head, tail=args.tail)
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.out_path)), exist_ok=True)
+    with open(args.out_path, "w", encoding="utf-8") as f:
+        json.dump(truncated, f, ensure_ascii=False, indent=2)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_openhands_conversation_export_scripts.py
+++ b/tests/test_openhands_conversation_export_scripts.py
@@ -1,0 +1,136 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "skills" / "openhands-conversation-export" / "scripts"
+
+
+class TestOpenHandsConversationExportScripts(unittest.TestCase):
+    def test_truncate_json_redacts_and_truncates(self) -> None:
+        token = "ghu_abcdefghijklmnopqrstuvwxyz123456"
+        payload = {
+            "session_api_key": "session-secret",
+            "nested": {
+                "api_key": "api-secret",
+                "text": f"Authorization: Bearer {token}",
+            },
+            "long": "x" * 160,
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            input_path = td_path / "input.json"
+            output_path = td_path / "output.json"
+            input_path.write_text(json.dumps(payload), encoding="utf-8")
+
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPTS_DIR / "truncate_json.py"),
+                    "--input-path",
+                    str(input_path),
+                    "--output-path",
+                    str(output_path),
+                    "--max-len",
+                    "60",
+                    "--head",
+                    "10",
+                    "--tail",
+                    "10",
+                ],
+                check=True,
+            )
+
+            result = json.loads(output_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(result["session_api_key"], "<redacted>")
+        self.assertEqual(result["nested"]["api_key"], "<redacted>")
+        self.assertIn("<truncated", result["long"])
+        self.assertIn("Authorization: Bearer <redacted>", result["nested"]["text"])
+        self.assertNotIn(token, result["nested"]["text"])
+
+    def test_render_markdown_outputs_transcript_and_redacts_tokens(self) -> None:
+        token = "ghp_abcdefghijklmnopqrstuvwxyz123456"
+        payload = {
+            "conversation": {
+                "conversation_id": "conv-123",
+                "title": "Demo conversation",
+                "selected_repository": "enyst/.openhands",
+                "selected_branch": "main",
+                "created_at": "2026-01-01T00:00:00Z",
+                "last_updated_at": "2026-01-01T00:01:00Z",
+                "status": "RUNNING",
+            },
+            "events": [
+                {
+                    "id": 1,
+                    "source": "environment",
+                    "action": "run",
+                    "timestamp": "2026-01-01T00:00:01Z",
+                    "args": {"command": "echo hi"},
+                },
+                {
+                    "id": 2,
+                    "source": "environment",
+                    "observation": "run",
+                    "cause": 1,
+                    "timestamp": "2026-01-01T00:00:02Z",
+                    "content": f"Authorization: Bearer {token}",
+                },
+                {
+                    "id": 3,
+                    "source": "user",
+                    "action": "message",
+                    "timestamp": "2026-01-01T00:00:03Z",
+                    "args": {"content": "please export this"},
+                },
+                {
+                    "id": 4,
+                    "source": "agent",
+                    "action": "message",
+                    "timestamp": "2026-01-01T00:00:04Z",
+                    "content": "done",
+                },
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            input_path = td_path / "input.json"
+            output_path = td_path / "output.md"
+            input_path.write_text(json.dumps(payload), encoding="utf-8")
+
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPTS_DIR / "render_markdown.py"),
+                    "--input-path",
+                    str(input_path),
+                    "--output-path",
+                    str(output_path),
+                    "--head",
+                    "20",
+                    "--tail",
+                    "20",
+                ],
+                check=True,
+            )
+
+            markdown = output_path.read_text(encoding="utf-8")
+
+        self.assertIn("# Demo conversation", markdown)
+        self.assertIn("- Conversation ID: `conv-123`", markdown)
+        self.assertIn("<details>", markdown)
+        self.assertIn("### User · 2026-01-01T00:00:03Z · id=3", markdown)
+        self.assertIn("### Assistant · 2026-01-01T00:00:04Z · id=4", markdown)
+        self.assertIn("Authorization: Bearer <redacted>", markdown)
+        self.assertNotIn(token, markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_openhands_conversation_export_scripts.py
+++ b/tests/test_openhands_conversation_export_scripts.py
@@ -1,23 +1,45 @@
 import json
+import os
 import subprocess
 import sys
 import tempfile
+import threading
 import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS_DIR = REPO_ROOT / "skills" / "openhands-conversation-export" / "scripts"
+SCANNER_SAFE_BEARER = "scanner_safe_bearer_token_for_tests_only"
 
 
 class TestOpenHandsConversationExportScripts(unittest.TestCase):
+    def _run_script(
+        self,
+        script_name: str,
+        *args: str,
+        check: bool = True,
+        **kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env.update(kwargs.pop("env", {}))
+        return subprocess.run(
+            [sys.executable, str(SCRIPTS_DIR / script_name), *args],
+            check=check,
+            timeout=30,
+            text=True,
+            env=env,
+            **kwargs,
+        )
+
     def test_truncate_json_redacts_and_truncates(self) -> None:
-        token = "ghu_abcdefghijklmnopqrstuvwxyz123456"
         payload = {
             "session_api_key": "session-secret",
             "nested": {
                 "api_key": "api-secret",
-                "text": f"Authorization: Bearer {token}",
+                "text": f"Authorization: Bearer {SCANNER_SAFE_BEARER}",
             },
             "long": "x" * 160,
         }
@@ -28,22 +50,18 @@ class TestOpenHandsConversationExportScripts(unittest.TestCase):
             output_path = td_path / "output.json"
             input_path.write_text(json.dumps(payload), encoding="utf-8")
 
-            subprocess.run(
-                [
-                    sys.executable,
-                    str(SCRIPTS_DIR / "truncate_json.py"),
-                    "--input-path",
-                    str(input_path),
-                    "--output-path",
-                    str(output_path),
-                    "--max-len",
-                    "60",
-                    "--head",
-                    "10",
-                    "--tail",
-                    "10",
-                ],
-                check=True,
+            self._run_script(
+                "truncate_json.py",
+                "--input-path",
+                str(input_path),
+                "--output-path",
+                str(output_path),
+                "--max-len",
+                "60",
+                "--head",
+                "10",
+                "--tail",
+                "10",
             )
 
             result = json.loads(output_path.read_text(encoding="utf-8"))
@@ -52,10 +70,9 @@ class TestOpenHandsConversationExportScripts(unittest.TestCase):
         self.assertEqual(result["nested"]["api_key"], "<redacted>")
         self.assertIn("<truncated", result["long"])
         self.assertIn("Authorization: Bearer <redacted>", result["nested"]["text"])
-        self.assertNotIn(token, result["nested"]["text"])
+        self.assertNotIn(SCANNER_SAFE_BEARER, result["nested"]["text"])
 
     def test_render_markdown_outputs_transcript_and_redacts_tokens(self) -> None:
-        token = "ghp_abcdefghijklmnopqrstuvwxyz123456"
         payload = {
             "conversation": {
                 "conversation_id": "conv-123",
@@ -80,7 +97,7 @@ class TestOpenHandsConversationExportScripts(unittest.TestCase):
                     "observation": "run",
                     "cause": 1,
                     "timestamp": "2026-01-01T00:00:02Z",
-                    "content": f"Authorization: Bearer {token}",
+                    "content": f"Authorization: Bearer {SCANNER_SAFE_BEARER}",
                 },
                 {
                     "id": 3,
@@ -105,20 +122,16 @@ class TestOpenHandsConversationExportScripts(unittest.TestCase):
             output_path = td_path / "output.md"
             input_path.write_text(json.dumps(payload), encoding="utf-8")
 
-            subprocess.run(
-                [
-                    sys.executable,
-                    str(SCRIPTS_DIR / "render_markdown.py"),
-                    "--input-path",
-                    str(input_path),
-                    "--output-path",
-                    str(output_path),
-                    "--head",
-                    "20",
-                    "--tail",
-                    "20",
-                ],
-                check=True,
+            self._run_script(
+                "render_markdown.py",
+                "--input-path",
+                str(input_path),
+                "--output-path",
+                str(output_path),
+                "--head",
+                "20",
+                "--tail",
+                "20",
             )
 
             markdown = output_path.read_text(encoding="utf-8")
@@ -129,7 +142,122 @@ class TestOpenHandsConversationExportScripts(unittest.TestCase):
         self.assertIn("### User · 2026-01-01T00:00:03Z · id=3", markdown)
         self.assertIn("### Assistant · 2026-01-01T00:00:04Z · id=4", markdown)
         self.assertIn("Authorization: Bearer <redacted>", markdown)
-        self.assertNotIn(token, markdown)
+        self.assertNotIn(SCANNER_SAFE_BEARER, markdown)
+
+    def test_render_markdown_keeps_tool_only_transcripts(self) -> None:
+        payload = {
+            "conversation": {
+                "conversation_id": "conv-tools-only",
+                "title": "Tool only conversation",
+            },
+            "events": [
+                {
+                    "id": 1,
+                    "source": "environment",
+                    "action": "run",
+                    "timestamp": "2026-01-01T00:00:01Z",
+                    "args": {"command": "echo hi"},
+                },
+                {
+                    "id": 2,
+                    "source": "environment",
+                    "observation": "run",
+                    "cause": 1,
+                    "timestamp": "2026-01-01T00:00:02Z",
+                    "content": "hi\n",
+                },
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            input_path = td_path / "input.json"
+            output_path = td_path / "output.md"
+            input_path.write_text(json.dumps(payload), encoding="utf-8")
+
+            self._run_script(
+                "render_markdown.py",
+                "--input-path",
+                str(input_path),
+                "--output-path",
+                str(output_path),
+            )
+
+            markdown = output_path.read_text(encoding="utf-8")
+
+        self.assertIn("# Tool only conversation", markdown)
+        self.assertIn("Tool calls / results (2 events)", markdown)
+        self.assertIn("action=run", markdown)
+        self.assertIn("observation=run", markdown)
+
+    def test_export_conversation_rejects_missing_id_on_non_terminal_page(self) -> None:
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:  # noqa: N802
+                parsed = urlparse(self.path)
+                if parsed.path == "/api/conversations/conv-123":
+                    payload = {
+                        "conversation_id": "conv-123",
+                        "title": "Demo export",
+                        "status": "RUNNING",
+                    }
+                elif parsed.path == "/api/conversations/conv-123/events":
+                    start_id = parse_qs(parsed.query).get("start_id", ["0"])[0]
+                    if start_id == "0":
+                        payload = {
+                            "events": [
+                                {
+                                    "source": "user",
+                                    "action": "message",
+                                    "args": {"content": "hi"},
+                                }
+                            ],
+                            "has_more": True,
+                        }
+                    else:
+                        payload = {"events": [], "has_more": False}
+                else:
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+
+                body = json.dumps(payload).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+                return
+
+        with HTTPServer(("127.0.0.1", 0), Handler) as server, tempfile.TemporaryDirectory() as td:
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            output_path = Path(td) / "export.json"
+
+            result = self._run_script(
+                "export_conversation.py",
+                "--base-url",
+                f"http://127.0.0.1:{server.server_port}",
+                "--conversation-id",
+                "conv-123",
+                "--out",
+                str(output_path),
+                check=False,
+                capture_output=True,
+                env={"OPENHANDS_API_KEY": "test-api-key"},
+            )
+            output_exists = output_path.exists()
+
+            server.shutdown()
+            thread.join(timeout=5)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "Expected integer id on last event when has_more=true",
+            result.stderr,
+        )
+        self.assertFalse(output_exists)
 
 
 if __name__ == "__main__":

--- a/tests/test_python_scripts_compile.py
+++ b/tests/test_python_scripts_compile.py
@@ -21,6 +21,16 @@ class TestSkillPythonScriptsCompile(unittest.TestCase):
     def test_babysit_pr_watch_compiles(self) -> None:
         self._compile("skills/babysit-pr/scripts/gh_pr_watch.py")
 
+    def test_openhands_conversation_export_scripts_compile(self) -> None:
+        for rel_path in (
+            "skills/openhands-conversation-export/scripts/export_conversation.py",
+            "skills/openhands-conversation-export/scripts/truncate_json.py",
+            "skills/openhands-conversation-export/scripts/render_markdown.py",
+            "skills/openhands-conversation-export/scripts/redaction.py",
+        ):
+            with self.subTest(rel_path=rel_path):
+                self._compile(rel_path)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add a new `openhands-conversation-export` skill with Agent Skills-style metadata and step-by-step usage guidance
- include stdlib-only Python scripts to export raw conversation events, create redacted truncated JSON, and render markdown transcripts
- add compile coverage plus functional tests for the new transcript/truncation scripts

## Testing
- `python -m unittest discover -s /workspace/project/dot-openhands/tests -v`

Closes #13.

_This PR was created by an AI assistant (OpenHands) on behalf of enyst._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/14d96978-3fb3-45c4-aefc-a26f8d497469)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added conversation export functionality to download OpenHands Cloud conversation event streams as JSON.
  * Added automatic redaction of sensitive credentials in exports.
  * Added markdown transcript rendering for human-readable conversation summaries.
  * Added JSON truncation to manage large export files.

* **Documentation**
  * Added skill documentation and quick-start guide for the conversation export workflow.

* **Tests**
  * Added test coverage for export, redaction, and transcript rendering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->