### PR TITLE
Align reviewer PAT secret name in reference

### DIFF
--- a/skills/add-openhands-reviewer/references/reviewer-setup-reference.md
+++ b/skills/add-openhands-reviewer/references/reviewer-setup-reference.md
@@ -184,7 +184,7 @@ jobs:
           llm-api-key: ${{ secrets.LLM_API_KEY }}
           github-app-id: ${{ secrets.OH_REVIEWER_APP_ID }}
           github-app-private-key: ${{ secrets.OH_REVIEWER_APP_PRIVATE_KEY }}
-          github-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+          github-token: ${{ secrets.OPENHANDS_REVIEWER_GITHUB_TOKEN }}
           lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}
 ```
 


### PR DESCRIPTION
## Summary
- replace `ALLHANDS_BOT_GITHUB_PAT` with `OPENHANDS_REVIEWER_GITHUB_TOKEN` in the self-review workflow template
- align the reviewer setup reference with the main skill docs and the repo's existing PAT secret naming

## Validation
- `python3 -m unittest tests/test_python_scripts_compile.py`
- fixed-string sanity check confirming `OPENHANDS_REVIEWER_GITHUB_TOKEN` is used and `ALLHANDS_BOT_GITHUB_PAT` no longer appears in the reviewer reference

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ef216170-bd5b-4ed2-b93f-94f65552c574)