### PR TITLE
github-forwarders: add --no-linkify-upstream option

### DIFF
--- a/skills/github-forwarders/SKILL.md
+++ b/skills/github-forwarders/SKILL.md
@@ -102,6 +102,16 @@ For each integer `N` in `[START..MAX]` (in order):
 - Progress is tracked in a state file (default: `.forwarders/state.json`).
 - Every processed number appends a JSONL record (default: `.forwarders/run.jsonl`).
 
+## No-linkify mode (recommended for first runs)
+
+By default, GitHub may turn upstream references into links and cross-repo references (which can trigger notifications).
+
+For initial staging runs, pass:
+
+- `--no-linkify-upstream`
+
+This renders the upstream token (e.g. `OpenHands/OpenHands#1234`) and the canonical URL as inline code so it is easy to copy/paste, but GitHub should not treat it as an actionable link.
+
 ## Dry-run semantics
 
 `--dry-run` performs no GitHub writes, but it still:
@@ -154,6 +164,7 @@ python3 <this-skill-path>/scripts/sync_forwarders.py \
   --start 1 \
   --max 100 \
   --max-cap 14000 \
+  --no-linkify-upstream \
   --dry-run
 ```
 

--- a/skills/github-forwarders/scripts/sync_forwarders.py
+++ b/skills/github-forwarders/scripts/sync_forwarders.py
@@ -156,6 +156,23 @@ def forwarder_marker_token(upstream_repo: Repo, number: int) -> str:
     return f"{upstream_repo.owner}/{upstream_repo.name}#{number}"
 
 
+def forwarder_issue_title(
+    *,
+    upstream_repo: Repo,
+    number: int,
+    upstream_found: bool,
+    no_linkify_upstream: bool,
+) -> str:
+    if no_linkify_upstream:
+        suffix = "" if upstream_found else ", upstream missing"
+        return f"Forwarder {number} ({upstream_repo.owner}/{upstream_repo.name}{suffix})"
+
+    if upstream_found:
+        return f"Forwarder: {upstream_repo.owner}/{upstream_repo.name}#{number}"
+
+    return f"Forwarder (missing upstream): {upstream_repo.owner}/{upstream_repo.name}#{number}"
+
+
 def forwarder_marker_comment(marker_token: str) -> str:
     return f"<!-- forwarder: {marker_token} -->\n"
 
@@ -354,14 +371,12 @@ def run_sync(
         updated = False
 
         if target_item is None:
-            if no_linkify_upstream:
-                title = f"Forwarder {n} ({upstream.owner}/{upstream.name})"
-                if not upstream_found:
-                    title = f"Forwarder {n} ({upstream.owner}/{upstream.name}, upstream missing)"
-            else:
-                title = f"Forwarder: {upstream.owner}/{upstream.name}#{n}"
-                if not upstream_found:
-                    title = f"Forwarder (missing upstream): {upstream.owner}/{upstream.name}#{n}"
+            title = forwarder_issue_title(
+                upstream_repo=upstream,
+                number=n,
+                upstream_found=upstream_found,
+                no_linkify_upstream=no_linkify_upstream,
+            )
             body = forwarder_block(
                 upstream_repo=upstream,
                 target_repo=target,

--- a/skills/github-forwarders/scripts/sync_forwarders.py
+++ b/skills/github-forwarders/scripts/sync_forwarders.py
@@ -164,14 +164,25 @@ def find_forwarder_marker_tokens(body: str) -> list[str]:
     return MARKER_RE.findall(body)
 
 
-def forwarder_block(*, upstream_repo: Repo, target_repo: Repo, number: int, canonical_url: str | None) -> str:
+def forwarder_block(
+    *,
+    upstream_repo: Repo,
+    target_repo: Repo,
+    number: int,
+    canonical_url: str | None,
+    no_linkify_upstream: bool,
+) -> str:
     marker_token = forwarder_marker_token(upstream_repo, number)
-    title = f"Forwarder: {marker_token}"
+
+    title_token = f"`{marker_token}`" if no_linkify_upstream else marker_token
+    title = f"Forwarder: {title_token}"
 
     if canonical_url is None:
-        canonical_line = "**Canonical location:** (upstream item not found)"
+        canonical_target = "(upstream item not found)"
     else:
-        canonical_line = f"**Canonical location:** {canonical_url}"
+        canonical_target = f"`{canonical_url}`" if no_linkify_upstream else canonical_url
+
+    canonical_line = f"**Canonical location:** {canonical_target}"
 
     return (
         "---\n"
@@ -302,6 +313,7 @@ def run_sync(
     max_cap: int,
     max_number: int | None,
     dry_run: bool,
+    no_linkify_upstream: bool,
     sleep_s: float,
     state_path: Path,
     log_path: Path,
@@ -342,14 +354,20 @@ def run_sync(
         updated = False
 
         if target_item is None:
-            title = f"Forwarder: {upstream.owner}/{upstream.name}#{n}"
-            if not upstream_found:
-                title = f"Forwarder (missing upstream): {upstream.owner}/{upstream.name}#{n}"
+            if no_linkify_upstream:
+                title = f"Forwarder {n} ({upstream.owner}/{upstream.name})"
+                if not upstream_found:
+                    title = f"Forwarder {n} ({upstream.owner}/{upstream.name}, upstream missing)"
+            else:
+                title = f"Forwarder: {upstream.owner}/{upstream.name}#{n}"
+                if not upstream_found:
+                    title = f"Forwarder (missing upstream): {upstream.owner}/{upstream.name}#{n}"
             body = forwarder_block(
                 upstream_repo=upstream,
                 target_repo=target,
                 number=n,
                 canonical_url=canonical_url,
+                no_linkify_upstream=no_linkify_upstream,
             )
             resp = create_issue(
                 client,
@@ -378,6 +396,7 @@ def run_sync(
                 target_repo=target,
                 number=n,
                 canonical_url=canonical_url,
+                no_linkify_upstream=no_linkify_upstream,
             )
 
             try:
@@ -457,6 +476,14 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--max-cap", type=int, default=14000)
     parser.add_argument("--sleep", type=float, default=1.25)
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--no-linkify-upstream",
+        action="store_true",
+        help=(
+            "Render upstream references (owner/repo#N and canonical URL) as code so they do not "
+            "autolink/cross-reference on GitHub. Useful for initial staging runs."
+        ),
+    )
     parser.add_argument("--state-file", type=Path, default=Path(".forwarders/state.json"))
     parser.add_argument("--log-file", type=Path, default=Path(".forwarders/run.jsonl"))
 
@@ -480,6 +507,7 @@ def main(argv: list[str]) -> int:
             max_cap=args.max_cap,
             max_number=args.max,
             dry_run=args.dry_run,
+            no_linkify_upstream=args.no_linkify_upstream,
             sleep_s=args.sleep,
             state_path=args.state_file,
             log_path=args.log_file,

--- a/tests/test_github_forwarders_logic.py
+++ b/tests/test_github_forwarders_logic.py
@@ -64,6 +64,8 @@ class TestGitHubForwardersLogic(unittest.TestCase):
 
         self.assertIn("# Forwarder: `OpenHands/OpenHands#10`", text)
         self.assertIn(f"**Canonical location:** `{url}`", text)
+        self.assertNotIn("# Forwarder: OpenHands/OpenHands#10", text)
+        self.assertNotIn(f"**Canonical location:** {url}", text)
 
 
     def test_prepend_forwarder_noops_on_exact_marker(self) -> None:

--- a/tests/test_github_forwarders_logic.py
+++ b/tests/test_github_forwarders_logic.py
@@ -35,6 +35,7 @@ class TestGitHubForwardersLogic(unittest.TestCase):
             target_repo=target,
             number=1,
             canonical_url="https://github.com/OpenHands/OpenHands/pull/1",
+            no_linkify_upstream=False,
         )
         expected = sync.forwarder_marker_token(upstream, 1)
 
@@ -49,6 +50,22 @@ class TestGitHubForwardersLogic(unittest.TestCase):
         self.assertIn("## Original content", result)
         self.assertTrue(result.rstrip().endswith(original_body.rstrip()))
 
+    def test_forwarder_block_no_linkify_uses_code_for_upstream_refs(self) -> None:
+        upstream = sync.Repo(owner="OpenHands", name="OpenHands")
+        target = sync.Repo(owner="enyst", name="openhands-web")
+        url = "https://github.com/OpenHands/OpenHands/pull/10"
+        text = sync.forwarder_block(
+            upstream_repo=upstream,
+            target_repo=target,
+            number=10,
+            canonical_url=url,
+            no_linkify_upstream=True,
+        )
+
+        self.assertIn("# Forwarder: `OpenHands/OpenHands#10`", text)
+        self.assertIn(f"**Canonical location:** `{url}`", text)
+
+
     def test_prepend_forwarder_noops_on_exact_marker(self) -> None:
         upstream = sync.Repo(owner="OpenHands", name="OpenHands")
         target = sync.Repo(owner="enyst", name="openhands-web")
@@ -59,6 +76,7 @@ class TestGitHubForwardersLogic(unittest.TestCase):
             target_repo=target,
             number=2,
             canonical_url="https://github.com/OpenHands/OpenHands/issues/2",
+            no_linkify_upstream=False,
         )
 
         result = sync.prepend_forwarder(
@@ -79,6 +97,7 @@ class TestGitHubForwardersLogic(unittest.TestCase):
             target_repo=target,
             number=3,
             canonical_url="https://github.com/OpenHands/OpenHands/pull/3",
+            no_linkify_upstream=False,
         )
 
         with self.assertRaises(sync.ForwarderMarkerMismatchError) as ctx:


### PR DESCRIPTION
Adds a safety switch for early staging runs.

- New flag: --no-linkify-upstream (renders upstream token + canonical URL as inline code to avoid cross-repo linkification/notifications)
- Documents the mode in SKILL.md and updates example command
- Adds unit coverage for the formatting

Co-authored-by: openhands <openhands@all-hands.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--no-linkify-upstream` option to prevent GitHub from converting upstream references into clickable links, recommended for initial runs.

* **Documentation**
  * Documented the new no-linkify mode option and usage examples for the synchronization script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->