### PR TITLE
github-forwarders: handle GitHub API rate limiting

### DIFF
--- a/skills/github-forwarders/SKILL.md
+++ b/skills/github-forwarders/SKILL.md
@@ -141,6 +141,20 @@ Recommended practice:
 - Disable GHCR-pushing workflows (e.g. Docker) to avoid publishing side effects.
 - Start with a small range (e.g. `--max 100`) on a staging repo.
 
+## Rate limiting
+
+The script includes basic automatic retry handling for GitHub rate limiting:
+
+- Retries on HTTP 403/429 when rate-limit headers or rate-limit messages are detected.
+- Uses `Retry-After` when present, otherwise sleeps until `X-RateLimit-Reset` (+ a small buffer).
+- Falls back to exponential backoff when only a rate-limit message is available.
+
+Tuning flags:
+
+- `--api-max-retries`
+- `--api-backoff-base-seconds`
+- `--api-reset-buffer-seconds`
+
 ## Commands
 
 Scan commit history (local clone) to find the maximum referenced `#NNN`:

--- a/skills/github-forwarders/scripts/sync_forwarders.py
+++ b/skills/github-forwarders/scripts/sync_forwarders.py
@@ -81,6 +81,13 @@ class GitHubClient:
         reset_buffer_seconds: int = 2,
         sleep_fn: Callable[[float], None] = time.sleep,
     ):
+        if max_retries < 0:
+            raise ValueError("max_retries must be >= 0")
+        if backoff_base_seconds < 0:
+            raise ValueError("backoff_base_seconds must be >= 0")
+        if reset_buffer_seconds < 0:
+            raise ValueError("reset_buffer_seconds must be >= 0")
+
         self._token = token
         self._max_retries = max_retries
         self._backoff_base_seconds = backoff_base_seconds

--- a/skills/github-forwarders/scripts/sync_forwarders.py
+++ b/skills/github-forwarders/scripts/sync_forwarders.py
@@ -15,7 +15,7 @@ import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 
 
 REF_RE = re.compile(r"#(\d{1,6})\b")
@@ -72,8 +72,20 @@ class Repo:
 
 
 class GitHubClient:
-    def __init__(self, token: str):
+    def __init__(
+        self,
+        token: str,
+        *,
+        max_retries: int = 8,
+        backoff_base_seconds: float = 2.0,
+        reset_buffer_seconds: int = 2,
+        sleep_fn: Callable[[float], None] = time.sleep,
+    ):
         self._token = token
+        self._max_retries = max_retries
+        self._backoff_base_seconds = backoff_base_seconds
+        self._reset_buffer_seconds = reset_buffer_seconds
+        self._sleep_fn = sleep_fn
 
     def request(
         self,
@@ -95,36 +107,76 @@ class GitHubClient:
             data = json.dumps(json_body).encode("utf-8")
             headers["Content-Type"] = "application/json"
 
-        req = urllib.request.Request(url, data=data, headers=headers, method=method)
-        try:
-            with urllib.request.urlopen(req, timeout=60) as resp:  # noqa: S310
-                status = getattr(resp, "status", 200)
-                raw = resp.read().decode("utf-8")
-
-                if status not in expected:
-                    snippet = raw[:5000] if raw else ""
-                    raise RuntimeError(
-                        f"Unexpected HTTP {status} for {method} {url} "
-                        f"(expected {expected}): {snippet}"
-                    )
-
-                if not raw:
-                    return None
-                return json.loads(raw)
-        except urllib.error.HTTPError as e:
-            if e.code == 404:
-                return None
-
-            body = None
+        attempt = 0
+        while True:
+            req = urllib.request.Request(url, data=data, headers=headers, method=method)
             try:
-                body = e.read().decode("utf-8")
-            except Exception:  # noqa: BLE001
-                body = None
+                with urllib.request.urlopen(req, timeout=60) as resp:  # noqa: S310
+                    status = getattr(resp, "status", 200)
+                    raw = resp.read().decode("utf-8")
 
-            msg = f"HTTP {e.code} for {method} {url}"
-            if body:
-                msg = f"{msg}: {body[:5000]}"
-            raise RuntimeError(msg) from e
+                    if status not in expected:
+                        snippet = raw[:5000] if raw else ""
+                        raise RuntimeError(
+                            f"Unexpected HTTP {status} for {method} {url} "
+                            f"(expected {expected}): {snippet}"
+                        )
+
+                    if not raw:
+                        return None
+                    return json.loads(raw)
+            except urllib.error.HTTPError as e:
+                if e.code == 404:
+                    return None
+
+                body = None
+                try:
+                    body = e.read().decode("utf-8")
+                except Exception:  # noqa: BLE001
+                    body = None
+                finally:
+                    try:
+                        e.close()
+                    except Exception:  # noqa: BLE001
+                        pass
+
+                wait_seconds: float | None = None
+                headers_obj = getattr(e, "headers", None)
+                if e.code in (403, 429) and headers_obj is not None:
+                    retry_after_raw = headers_obj.get("Retry-After")
+                    remaining_raw = headers_obj.get("X-RateLimit-Remaining")
+                    reset_raw = headers_obj.get("X-RateLimit-Reset")
+
+                    retry_after = int(retry_after_raw) if retry_after_raw and retry_after_raw.isdigit() else None
+                    remaining = int(remaining_raw) if remaining_raw and remaining_raw.isdigit() else None
+                    reset_epoch = int(reset_raw) if reset_raw and reset_raw.isdigit() else None
+
+                    lower = (body or "").lower()
+                    is_secondary = "secondary rate limit" in lower or "abuse detection" in lower
+                    is_primary = "rate limit exceeded" in lower
+
+                    if retry_after is not None and (is_secondary or e.code == 429):
+                        wait_seconds = float(max(0, retry_after))
+                    elif remaining == 0 and reset_epoch is not None:
+                        delta = reset_epoch - int(time.time())
+                        wait_seconds = float(max(0, delta) + self._reset_buffer_seconds)
+                    elif is_primary or is_secondary:
+                        wait_seconds = float(self._backoff_base_seconds * (2**attempt))
+
+                if wait_seconds is not None and attempt < self._max_retries:
+                    print(
+                        f"GitHub API rate limited (HTTP {e.code}). "
+                        f"Sleeping {wait_seconds:.1f}s then retrying ({attempt+1}/{self._max_retries})...",
+                        file=sys.stderr,
+                    )
+                    self._sleep_fn(wait_seconds)
+                    attempt += 1
+                    continue
+
+                msg = f"HTTP {e.code} for {method} {url}"
+                if body:
+                    msg = f"{msg}: {body[:5000]}"
+                raise RuntimeError(msg) from e
 
 
 def iter_git_log_messages(repo_path: Path, rev: str) -> Iterable[str]:
@@ -331,12 +383,20 @@ def run_sync(
     max_number: int | None,
     dry_run: bool,
     no_linkify_upstream: bool,
+    api_max_retries: int,
+    api_backoff_base_seconds: float,
+    api_reset_buffer_seconds: int,
     sleep_s: float,
     state_path: Path,
     log_path: Path,
 ) -> None:
     token = get_auth_token()
-    client = GitHubClient(token=token)
+    client = GitHubClient(
+        token=token,
+        max_retries=api_max_retries,
+        backoff_base_seconds=api_backoff_base_seconds,
+        reset_buffer_seconds=api_reset_buffer_seconds,
+    )
 
     ensure_label_exists(client, target, "forwarder", dry_run=dry_run)
 
@@ -500,6 +560,25 @@ def main(argv: list[str]) -> int:
         ),
     )
     parser.add_argument("--state-file", type=Path, default=Path(".forwarders/state.json"))
+    parser.add_argument(
+        "--api-max-retries",
+        type=int,
+        default=8,
+        help="Maximum number of automatic retries on GitHub rate limiting.",
+    )
+    parser.add_argument(
+        "--api-backoff-base-seconds",
+        type=float,
+        default=2.0,
+        help="Base seconds for exponential backoff when rate-limit headers are missing.",
+    )
+    parser.add_argument(
+        "--api-reset-buffer-seconds",
+        type=int,
+        default=2,
+        help="Extra seconds added when sleeping until X-RateLimit-Reset.",
+    )
+
     parser.add_argument("--log-file", type=Path, default=Path(".forwarders/run.jsonl"))
 
     args = parser.parse_args(argv)
@@ -523,6 +602,9 @@ def main(argv: list[str]) -> int:
             max_number=args.max,
             dry_run=args.dry_run,
             no_linkify_upstream=args.no_linkify_upstream,
+            api_max_retries=args.api_max_retries,
+            api_backoff_base_seconds=args.api_backoff_base_seconds,
+            api_reset_buffer_seconds=args.api_reset_buffer_seconds,
             sleep_s=args.sleep,
             state_path=args.state_file,
             log_path=args.log_file,

--- a/skills/github-forwarders/scripts/sync_forwarders.py
+++ b/skills/github-forwarders/scripts/sync_forwarders.py
@@ -134,6 +134,10 @@ class GitHubClient:
                     return json.loads(raw)
             except urllib.error.HTTPError as e:
                 if e.code == 404:
+                    try:
+                        e.close()
+                    except Exception:  # noqa: BLE001
+                        pass
                     return None
 
                 body = None
@@ -148,27 +152,38 @@ class GitHubClient:
                         pass
 
                 wait_seconds: float | None = None
+
+                lower = (body or "").lower()
+                is_secondary = "secondary rate limit" in lower or "abuse detection" in lower
+                is_primary = "rate limit exceeded" in lower
+                is_rate_limit = e.code == 429 or is_primary or is_secondary
+
+                retry_after: int | None = None
+                remaining: int | None = None
+                reset_epoch: int | None = None
+
                 headers_obj = getattr(e, "headers", None)
                 if e.code in (403, 429) and headers_obj is not None:
                     retry_after_raw = headers_obj.get("Retry-After")
                     remaining_raw = headers_obj.get("X-RateLimit-Remaining")
                     reset_raw = headers_obj.get("X-RateLimit-Reset")
 
-                    retry_after = int(retry_after_raw) if retry_after_raw and retry_after_raw.isdigit() else None
-                    remaining = int(remaining_raw) if remaining_raw and remaining_raw.isdigit() else None
-                    reset_epoch = int(reset_raw) if reset_raw and reset_raw.isdigit() else None
+                    if retry_after_raw and retry_after_raw.isdigit():
+                        retry_after = int(retry_after_raw)
 
-                    lower = (body or "").lower()
-                    is_secondary = "secondary rate limit" in lower or "abuse detection" in lower
-                    is_primary = "rate limit exceeded" in lower
+                    if remaining_raw and remaining_raw.isdigit():
+                        remaining = int(remaining_raw)
 
-                    if retry_after is not None and (is_secondary or e.code == 429):
-                        wait_seconds = float(max(0, retry_after))
-                    elif remaining == 0 and reset_epoch is not None:
-                        delta = reset_epoch - int(time.time())
-                        wait_seconds = float(max(0, delta) + self._reset_buffer_seconds)
-                    elif is_primary or is_secondary:
-                        wait_seconds = float(self._backoff_base_seconds * (2**attempt))
+                    if reset_raw and reset_raw.isdigit():
+                        reset_epoch = int(reset_raw)
+
+                if remaining == 0 and reset_epoch is not None:
+                    delta = reset_epoch - int(time.time())
+                    wait_seconds = float(max(0, delta) + self._reset_buffer_seconds)
+                elif retry_after is not None and is_rate_limit:
+                    wait_seconds = float(max(0, retry_after))
+                elif is_rate_limit:
+                    wait_seconds = float(self._backoff_base_seconds * (2**attempt))
 
                 if wait_seconds is not None and attempt < self._max_retries:
                     print(

--- a/tests/test_github_forwarders_logic.py
+++ b/tests/test_github_forwarders_logic.py
@@ -2,6 +2,7 @@ import importlib.util
 import json
 import sys
 import threading
+import time
 import unittest
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -149,6 +150,65 @@ class TestGitHubForwardersLogic(unittest.TestCase):
 
             created = client.request("GET", base_url + "/created", expected=(201,))
             self.assertEqual(created, {"ok": True})
+
+    def test_github_client_retries_on_primary_rate_limit(self) -> None:
+        class Handler(BaseHTTPRequestHandler):
+            calls = 0
+
+            def do_GET(self) -> None:  # noqa: N802
+                Handler.calls += 1
+
+                if self.path == "/rate":
+                    if Handler.calls == 1:
+                        payload = {"message": "API rate limit exceeded"}
+                        body = json.dumps(payload).encode("utf-8")
+                        self.send_response(403)
+                        self.send_header("Content-Type", "application/json")
+                        self.send_header("X-RateLimit-Remaining", "0")
+                        self.send_header("X-RateLimit-Reset", str(int(time.time()) - 1))
+                        self.send_header("Content-Length", str(len(body)))
+                        self.end_headers()
+                        self.wfile.write(body)
+                        return
+
+                    payload = {"ok": True}
+                    body = json.dumps(payload).encode("utf-8")
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Content-Length", str(len(body)))
+                    self.end_headers()
+                    self.wfile.write(body)
+                    return
+
+                self.send_response(404)
+                self.end_headers()
+
+            def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+                return
+
+        sleep_calls: list[float] = []
+
+        def fake_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        with HTTPServer(("127.0.0.1", 0), Handler) as server:
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            base_url = f"http://127.0.0.1:{server.server_port}"
+
+            client = sync.GitHubClient(
+                token="test-token",
+                max_retries=2,
+                backoff_base_seconds=0.0,
+                reset_buffer_seconds=0,
+                sleep_fn=fake_sleep,
+            )
+            result = client.request("GET", base_url + "/rate", expected=(200,))
+
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(Handler.calls, 2)
+        self.assertGreaterEqual(len(sleep_calls), 1)
+
 
 
 if __name__ == "__main__":

--- a/tests/test_github_forwarders_logic.py
+++ b/tests/test_github_forwarders_logic.py
@@ -210,6 +210,97 @@ class TestGitHubForwardersLogic(unittest.TestCase):
         self.assertGreaterEqual(len(sleep_calls), 1)
 
 
+    def test_github_client_stops_after_max_retries(self) -> None:
+        class Handler(BaseHTTPRequestHandler):
+            calls = 0
+
+            def do_GET(self) -> None:  # noqa: N802
+                Handler.calls += 1
+
+                if self.path != "/rate":
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+
+                payload = {"message": "API rate limit exceeded"}
+                body = json.dumps(payload).encode("utf-8")
+                self.send_response(403)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("X-RateLimit-Remaining", "0")
+                self.send_header("X-RateLimit-Reset", str(int(time.time()) - 1))
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+                return
+
+        sleep_calls: list[float] = []
+
+        def fake_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        with HTTPServer(("127.0.0.1", 0), Handler) as server:
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            base_url = f"http://127.0.0.1:{server.server_port}"
+
+            client = sync.GitHubClient(
+                token="test-token",
+                max_retries=2,
+                backoff_base_seconds=0.0,
+                reset_buffer_seconds=0,
+                sleep_fn=fake_sleep,
+            )
+
+            with self.assertRaises(RuntimeError):
+                client.request("GET", base_url + "/rate", expected=(200,))
+
+        self.assertEqual(Handler.calls, 3)
+        self.assertEqual(len(sleep_calls), 2)
+
+    def test_github_client_does_not_retry_non_rate_limit_403(self) -> None:
+        class Handler(BaseHTTPRequestHandler):
+            calls = 0
+
+            def do_GET(self) -> None:  # noqa: N802
+                Handler.calls += 1
+                payload = {"message": "forbidden"}
+                body = json.dumps(payload).encode("utf-8")
+                self.send_response(403)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+                return
+
+        sleep_calls: list[float] = []
+
+        def fake_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        with HTTPServer(("127.0.0.1", 0), Handler) as server:
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            base_url = f"http://127.0.0.1:{server.server_port}"
+
+            client = sync.GitHubClient(
+                token="test-token",
+                max_retries=5,
+                backoff_base_seconds=0.0,
+                reset_buffer_seconds=0,
+                sleep_fn=fake_sleep,
+            )
+
+            with self.assertRaises(RuntimeError):
+                client.request("GET", base_url + "/rate", expected=(200,))
+
+        self.assertEqual(Handler.calls, 1)
+        self.assertEqual(sleep_calls, [])
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR makes the forwarder sync script safer for long-running bulk updates (e.g. 1..14000) by adding automatic retry behavior for GitHub API rate limiting.

What changed
- GitHubClient now retries requests when it sees HTTP 403/429 rate limiting.
  - Primary rate limit: uses X-RateLimit-Remaining=0 + X-RateLimit-Reset (+ buffer)
  - Secondary/abuse limit: uses Retry-After when present
  - Fallback: exponential backoff when only rate-limit text is available
- Added CLI tuning flags: --api-max-retries, --api-backoff-base-seconds, --api-reset-buffer-seconds
- Added unit coverage with a local HTTPServer that returns a 403 rate-limit response once, then 200.
- Documented rate limiting behavior + tuning in SKILL.md

What reviewers should look for
- Retry triggers only on rate-limit-like responses (403/429) and does NOT mask other errors.
- Request stops after max retries and raises.
- No commit rewriting behavior is unchanged.

Co-authored-by: openhands <openhands@all-hands.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Script now automatically retries GitHub API calls when rate-limited, respecting server rate-limit signals and using exponential backoff.
  * Added CLI flags to tune retry behavior: --api-max-retries, --api-backoff-base-seconds, --api-reset-buffer-seconds.

* **Tests**
  * Added unit tests covering retry behavior, stop-after-max-retries, and non-retry for non-rate-limit 403 responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

Note: This repo is configured to receive AI reviews from CodeRabbit + Gemini, and we also expect Devin AI to review new PRs. If Devin does not appear automatically, please flag it.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/.openhands/pull/22" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
